### PR TITLE
[LC46][Go][Backtracking][v1]

### DIFF
--- a/leetcode/46-Permutations/go/permutations.go
+++ b/leetcode/46-Permutations/go/permutations.go
@@ -28,7 +28,9 @@ func permute(nums []int) [][]int {
 // `tmp`
 func backtrack(nums []int, tmp []int, invalid_pos []bool, res [][]int) [][]int {
 	if len(tmp) == len(nums) {
-		res = append(res, tmp)
+		tmp2 := make([]int, len(tmp))
+		copy(tmp2, tmp)
+		res = append(res, tmp2)
 	} else {
 		for i, num := range nums {
 			if invalid_pos[i] {

--- a/leetcode/46-Permutations/go/permutations.go
+++ b/leetcode/46-Permutations/go/permutations.go
@@ -28,6 +28,12 @@ func permute(nums []int) [][]int {
 // `tmp`
 func backtrack(nums []int, tmp []int, invalid_pos []bool, res [][]int) [][]int {
 	if len(tmp) == len(nums) {
+		// NOTE: make a copy to make leetcode OJ pass; not sure why I need to make a copy
+		// here. From Leetcode result, I'm suspecting a "Capturing Iteration Variable"
+		// (https://stackoverflow.com/questions/52980172/cannot-understand-5-6-1-caveat-capturing-iteration-variables)
+		// situation can happen. However, I cannot test it out given my current test implementation.
+		// Same implementation strategy (e.g., append(res, tmp)) is used in LC-401. However, OJ pass in that problem.
+		// I think it might be an error for OJ?
 		tmp2 := make([]int, len(tmp))
 		copy(tmp2, tmp)
 		res = append(res, tmp2)

--- a/leetcode/46-Permutations/go/permutations.go
+++ b/leetcode/46-Permutations/go/permutations.go
@@ -1,0 +1,45 @@
+package permutations
+
+// Given a collection of distinct integers, return all possible permutations.
+
+// Example:
+
+// Input: [1,2,3]
+// Output:
+// [
+//   [1,2,3],
+//   [1,3,2],
+//   [2,1,3],
+//   [2,3,1],
+//   [3,1,2],
+//   [3,2,1]
+// ]
+
+func permute(nums []int) [][]int {
+	var tmp []int
+	var res [][]int
+	invalid_pos := make([]bool, len(nums))
+	res = backtrack(nums, tmp, invalid_pos, res)
+	return res
+}
+
+// backtrack generates all the permutations of the given `nums` and put them into `res`.
+// `invalid_pos` keeps track of which number is valid to pick from `nums` to form a permutation
+// `tmp`
+func backtrack(nums []int, tmp []int, invalid_pos []bool, res [][]int) [][]int {
+	if len(tmp) == len(nums) {
+		res = append(res, tmp)
+	} else {
+		for i, num := range nums {
+			if invalid_pos[i] {
+				continue
+			}
+			invalid_pos[i] = true
+			tmp = append(tmp, num)
+			res = backtrack(nums, tmp, invalid_pos, res)
+			invalid_pos[i] = false
+			tmp = tmp[:len(tmp)-1]
+		}
+	}
+	return res
+}

--- a/leetcode/46-Permutations/go/permutations_test.go
+++ b/leetcode/46-Permutations/go/permutations_test.go
@@ -1,7 +1,10 @@
 package permutations
 
 import (
+	"errors"
+	"fmt"
 	"github.com/xxks-kkk/shuati/leetcode/goinclude"
+	"sync"
 	"testing"
 )
 
@@ -17,5 +20,35 @@ func TestPermute(t *testing.T) {
 		if got := permute(test.nums); !goinclude.IntNestedSliceCompare(got, test.want) {
 			t.Errorf("permute(%q) = %v", test.nums, got)
 		}
+	}
+}
+
+func TestPermuteInParallel(t *testing.T) {
+	var wg sync.WaitGroup
+	type test struct {
+		nums []int
+		want [][]int
+	}
+	tests := []test{
+		{[]int{1, 2, 3}, [][]int{{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {2, 3, 1}, {3, 1, 2}, {3, 2, 1}}},
+		{[]int{5, 4, 6, 2}, [][]int{{5, 4, 6, 2}, {5, 4, 2, 6}, {5, 6, 4, 2}, {5, 6, 2, 4}, {5, 2, 4, 6}, {5, 2, 6, 4}, {4, 5, 6, 2}, {4, 5, 2, 6}, {4, 6, 5, 2}, {4, 6, 2, 5}, {4, 2, 5, 6}, {4, 2, 6, 5}, {6, 5, 4, 2}, {6, 5, 2, 4}, {6, 4, 5, 2}, {6, 4, 2, 5}, {6, 2, 5, 4}, {6, 2, 4, 5}, {2, 5, 4, 6}, {2, 5, 6, 4}, {2, 4, 5, 6}, {2, 4, 6, 5}, {2, 6, 5, 4}, {2, 6, 4, 5}}},
+	}
+	done := make(chan error)
+	for _, testCase := range tests {
+		wg.Add(1)
+		go func(testCase test) {
+			defer wg.Done()
+			got := permute(testCase.nums)
+			if !goinclude.IntNestedSliceCompare(got, testCase.want) {
+				done <- errors.New(fmt.Sprintf("permute(%q) = %v", testCase.nums, got))
+			}
+		}(testCase)
+	}
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	for err := range done {
+		t.Error(err)
 	}
 }

--- a/leetcode/46-Permutations/go/permutations_test.go
+++ b/leetcode/46-Permutations/go/permutations_test.go
@@ -1,0 +1,21 @@
+package permutations
+
+import (
+	"github.com/xxks-kkk/shuati/leetcode/goinclude"
+	"testing"
+)
+
+func TestPermute(t *testing.T) {
+	var tests = []struct {
+		nums []int
+		want [][]int
+	}{
+		{[]int{1, 2, 3}, [][]int{{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {2, 3, 1}, {3, 1, 2}, {3, 2, 1}}},
+		{[]int{5, 4, 6, 2}, [][]int{{5, 4, 6, 2}, {5, 4, 2, 6}, {5, 6, 4, 2}, {5, 6, 2, 4}, {5, 2, 4, 6}, {5, 2, 6, 4}, {4, 5, 6, 2}, {4, 5, 2, 6}, {4, 6, 5, 2}, {4, 6, 2, 5}, {4, 2, 5, 6}, {4, 2, 6, 5}, {6, 5, 4, 2}, {6, 5, 2, 4}, {6, 4, 5, 2}, {6, 4, 2, 5}, {6, 2, 5, 4}, {6, 2, 4, 5}, {2, 5, 4, 6}, {2, 5, 6, 4}, {2, 4, 5, 6}, {2, 4, 6, 5}, {2, 6, 5, 4}, {2, 6, 4, 5}}},
+	}
+	for _, test := range tests {
+		if got := permute(test.nums); !goinclude.IntNestedSliceCompare(got, test.want) {
+			t.Errorf("permute(%q) = %v", test.nums, got)
+		}
+	}
+}

--- a/leetcode/46-Permutations/go/permutations_test.go
+++ b/leetcode/46-Permutations/go/permutations_test.go
@@ -52,3 +52,9 @@ func TestPermuteInParallel(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func BenchmarkPermute(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		permute([]int{5, 4, 6, 2})
+	}
+}

--- a/leetcode/goinclude/goinclude.go
+++ b/leetcode/goinclude/goinclude.go
@@ -2,7 +2,9 @@
 package goinclude
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 )
 
 // TODO: can make this more generic to compare two slice of elements with any type
@@ -23,4 +25,17 @@ func StringSliceCompare(s1 []string, s2 []string) bool {
 		}
 	}
 	return reflect.DeepEqual(seen_s1, seen_s2)
+}
+
+func IntNestedSliceCompare(n1 [][]int, n2 [][]int) bool {
+	var n1_string, n2_string []string
+	for _, num := range n1 {
+		tmp := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(num)), ","), "[]")
+		n1_string = append(n1_string, tmp)
+	}
+	for _, num := range n2 {
+		tmp := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(num)), ","), "[]")
+		n2_string = append(n1_string, tmp)
+	}
+	return StringSliceCompare(n1_string, n2_string)
 }

--- a/leetcode/goinclude/goinclude_test.go
+++ b/leetcode/goinclude/goinclude_test.go
@@ -20,3 +20,20 @@ func TestStringSliceCompare(t *testing.T) {
 		}
 	}
 }
+
+func TestIntNestedSliceCompare(t *testing.T) {
+	var tests = []struct {
+		n1   [][]int
+		n2   [][]int
+		want bool
+	}{
+		{[][]int{{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {2, 3, 1}, {3, 1, 2}, {3, 2, 1}}, [][]int{{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {2, 3, 1}, {3, 1, 2}, {3, 2, 1}}, true},
+		{[][]int{{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {2, 3, 1}, {3, 1, 2}, {3, 2, 1}}, [][]int{{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {2, 3, 1}, {3, 2, 1}, {3, 1, 2}}, true},
+		{[][]int{{1, 2, 3}, {1, 3, 2}, {2, 1, 3}, {2, 3, 1}, {3, 1, 2}, {3, 2, 1}}, [][]int{{1}}, false},
+	}
+	for _, test := range tests {
+		if got := IntNestedSliceCompare(test.n1, test.n2); got != test.want {
+			t.Errorf("IntNestedSliceCompare(%q, %q) = %v", test.n1, test.n2, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Resolves: [Leetcode 46](https://leetcode.com/problems/permutations/)

## Main Techniques:

Backtracking

## Testing

```
go test
```

## Performance

### Performance Metrics from OJ Platform

```
Runtime: 4 ms, faster than 91.97% of Go online submissions for Permutations.
Memory Usage: 6.9 MB, less than 100.00% of Go online submissions for Permutations.
```

### Performance Improved Since Last Change

## Questions

- Why do we need to have `copy(tmp2, tmp)`? Can we `append` `tmp` directly to `res`? Local test passed but OJ test case failed.
