### PR TITLE
[LC977][C++][Two Pointers][v1]

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,8 @@
-((nil . ((projectile-project-root . "/Users/zyh/Documents/projects/shuati"))))
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((nil
+  (projectile-project-root . "/Users/zyh/Documents/projects/shuati"))
+ (c++-mode
+  (flycheck-clang-language-standard . "c++11")))
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -460,6 +460,9 @@ add_executable(829
 add_executable(842
         leetcode/842-SplitArrayintoFibonacciSequence/splitArrayintoFibonacciSequence.cc)
 
+add_executable(977
+        leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc)
+      
 add_executable(00
         leetcode/cppinclude/queue.tpp
         leetcode/cppinclude/queue.h

--- a/leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc
+++ b/leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc
@@ -19,6 +19,51 @@ public:
         }
         return res;
     }
+
+  // Two pointers approach
+  vector<int> sortedSquares2(vector<int>& A) {
+    int ptr1 = 0;  // ptr1 points to the start of the negative number subsequence in A
+    int ptr2 = 0;  // ptr2 points to the start of the positive number subsequence in A
+    vector<int> res;
+    for(auto&& i: A)
+    {
+      if (i < 0)
+      {
+        ptr2++;
+      }
+      else {
+          break;
+      }
+    }
+    int ptr1_end = -1;
+    ptr1 = ptr2 - 1;
+    while (ptr1 != ptr1_end && ptr2 != A.size())
+    {
+      int cand1 = A[ptr1]*A[ptr1];
+      int cand2 = A[ptr2]*A[ptr2];
+      if (cand1 > cand2)
+      {
+        res.push_back(cand2);
+        ptr2++;
+      }
+      else
+      {
+        res.push_back(cand1);
+        ptr1--;
+      }
+    }
+    while(ptr1 != ptr1_end)
+    {
+      res.push_back(A[ptr1]*A[ptr1]);
+      ptr1--;
+    }
+    while(ptr2 != A.size())
+    {
+      res.push_back(A[ptr2]*A[ptr2]);
+      ptr2++;
+    }
+    return res;
+  }  
 };
 
 using ptr2sortedSquares = vector<int> (Solution::*)(vector<int>&);
@@ -42,5 +87,7 @@ void test(ptr2sortedSquares pfcn)
 int main()
 {
   ptr2sortedSquares pfcn = &Solution::sortedSquares;
+  test(pfcn);
+  pfcn = &Solution::sortedSquares2;
   test(pfcn);
 }

--- a/leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc
+++ b/leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc
@@ -1,0 +1,46 @@
+#include<vector>
+#include<assert.h>
+
+using namespace std;
+
+class Solution {
+public:
+    vector<int> sortedSquares(vector<int>& A) {
+        for(auto&& i: A)
+        {
+            if (i < 0)
+                i *= -1;
+        }
+        sort(A.begin(), A.end(), less<int>());
+        vector<int> res;
+        for(auto&& i: A)
+        {
+            res.push_back(i*i);
+        }
+        return res;
+    }
+};
+
+using ptr2sortedSquares = vector<int> (Solution::*)(vector<int>&);
+
+void test(ptr2sortedSquares pfcn)
+{
+    Solution sol;
+    struct testCase {
+      vector<int> input;
+      vector<int> expected;
+    };
+    vector<testCase> test_cases = {
+      {{-4,-1,0,3,10}, {0,1,9,16,100}},
+      {{-7,-3,2,3,11}, {4,9,9,49,121}},
+    };
+    for (auto && test_case: test_cases) {
+      assert((sol.*pfcn)(test_case.input) == test_case.expected);
+    }
+}
+
+int main()
+{
+  ptr2sortedSquares pfcn = &Solution::sortedSquares;
+  test(pfcn);
+}


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->

## Summary

Resolves: [Leetcode 977](https://leetcode.com/problems/squares-of-a-sorted-array/)

## Main Techniques:

The optimized approach using two pointers method:

**Intuition**

Since the array `A` is sorted, loosely speaking it has some negative elements with squares in decreasing order, then some non-negative elements with squares in increasing order.

For example, with `[-3, -2, -1, 4, 5, 6]`, we have the negative part `[-3, -2, -1]` with squares `[9, 4, 1]`, and the positive part `[4, 5, 6]` with squares `[16, 25, 36]`. Our strategy is to iterate over the negative part in reverse, and the positive part in the forward direction.

**Algorithm**

We can use two pointers to read the positive and negative parts of the array - one pointer `ptr2` in the positive direction of the positive subsequence, and another `ptr1` in the negative direction of the negative subsequence.

Now that we are reading two increasing arrays (the squares of the elements), we can merge these arrays together using a two-pointer technique.

## Testing


## Performance

### Performance Metrics from OJ Platform

- Two Pointers:

```
Runtime: 100 ms, faster than 83.48% of C++ online submissions for Squares of a Sorted Array.
Memory Usage: 14.5 MB, less than 32.43% of C++ online submissions for Squares of a Sorted Array.
```

- Sort:

```
Runtime: 128 ms, faster than 13.43% of C++ online submissions for Squares of a Sorted Array.
Memory Usage: 14.5 MB, less than 28.38% of C++ online submissions for Squares of a Sorted Array.
```

### Performance Improved Since Last Change
