### PR TITLE
[LC39][C++][Backtracking][v1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ add_executable(35
 
 add_executable(37
         leetcode/37-SudokuSolver/sudokuSolver.cc)
+
+add_executable(39
+        leetcode/39-CombinationSum/combinationSum.cc)
   
 add_executable(42
         leetcode/42-TrappingRainWater/trappingRainWater.cc)

--- a/leetcode/39-CombinationSum/combinationSum.cc
+++ b/leetcode/39-CombinationSum/combinationSum.cc
@@ -1,0 +1,90 @@
+// Given a set of candidate numbers (candidates) (without duplicates) and a target number (target), find all unique combinations in candidates where the candidate numbers sums to target.
+
+// The same repeated number may be chosen from candidates unlimited number of times.
+
+// Note:
+
+//     All numbers (including target) will be positive integers.
+//     The solution set must not contain duplicate combinations.
+
+// Example 1:
+
+// Input: candidates = [2,3,6,7], target = 7,
+// A solution set is:
+// [
+//   [7],
+//   [2,2,3]
+// ]
+
+// Example 2:
+
+// Input: candidates = [2,3,5], target = 8,
+// A solution set is:
+// [
+//   [2,2,2,2],
+//   [2,3,3],
+//   [3,5]
+// ]
+
+
+#include<vector>
+#include<numeric>
+
+using namespace std;
+
+class Solution {
+public:
+    vector<vector<int>> combinationSum(vector<int>& candidates, int target) {
+        vector<vector<int>> res;
+        vector<int> sol;
+        backtrack(res, candidates, target, sol, 0);
+        return res;
+    }
+private:
+    void backtrack(vector<vector<int>>& res, vector<int>& candidates, int target, vector<int>& sol, int lower_bound) {
+        int total = accumulate(sol.begin(), sol.end(), 0);
+        if (total > target) {
+            return;
+        }
+        if (total == target) {
+            res.push_back(sol);
+            return;
+        }
+        for(int i = lower_bound; i < candidates.size(); ++i) {
+            sol.push_back(candidates[i]);
+            backtrack(res, candidates, target, sol, i);
+            sol.pop_back();
+        }
+    }
+};
+
+using ptr2combinationSum = vector<vector<int>> (Solution::*) (vector<int>&, int);
+
+void test(ptr2combinationSum pfcn)
+{
+  Solution sol;
+  struct testCase {
+    vector<int> candidates;
+    int target;
+    vector<vector<int>> expected;
+  };
+  vector<testCase> test_cases = {
+    {{2,3,6,7}, 7, { {7}, {2,2,3}} },
+    {{2,3,5}, 8, { {2,2,2,2}, {2,3,3}, {3,5}}}
+  };
+  for(auto && test_case: test_cases) {
+    vector<vector<int>> got = (sol.*pfcn)(test_case.candidates, test_case.target);
+    for(auto&& item: got) {
+      if (find(test_case.expected.begin(), test_case.expected.end(), item) == test_case.expected.end())
+      {
+        assert(false);
+      }
+    }
+  }
+}
+
+int main()
+{
+  ptr2combinationSum pfcn = &Solution::combinationSum;
+  test(pfcn);
+}


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->

## Summary

Resolves: [Leetcode 39](https://leetcode.com/problems/combination-sum/)

## Main Techniques:

Backtracking. Note that since `[2,2,3]` is allowed for target `7` (i.e., the combination doesn't necessarily have to be a unique set of numbers), then we directly pass in `lower_bound` in the `backtrack` recursive call (`backtrack(res, candidates, target, sol, i);` not `i+1`). For comparison, see PR #135 

## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 16 ms, faster than 54.32% of C++ online submissions for Combination Sum.
Memory Usage: 9.4 MB, less than 94.44% of C++ online submissions for Combination Sum.
```

### Performance Improved Since Last Change
