### PR TITLE
[LC320][C++][Backtracking][v1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ add_executable(260
 add_executable(261
         leetcode/261-GraphValidTree/graphValidTree.cc)
 
-      add_executable(268
+add_executable(268
         leetcode/268-MissingNumber/missingNumber.cc)
 
 add_executable(270
@@ -316,7 +316,7 @@ add_executable(289
         leetcode/289-GameOfLife/gameOfLife.cc
         leetcode/cppinclude/cpputility.cc)
 
-      add_executable(291
+add_executable(291
         leetcode/291-WordPatternII/wordPatternII.cc)
 
 add_executable(295
@@ -332,10 +332,13 @@ add_executable(298
         leetcode/cppinclude/bt.cc)
 
 add_executable(301
-        leetcode/301-RemoveInvalidParentheses/removeInvalidParentheses.cc)
+  leetcode/301-RemoveInvalidParentheses/removeInvalidParentheses.cc)
 
 add_executable(305
-        leetcode/305-NumberOfIslandsII/numberOfIslandsII.cc)
+  leetcode/305-NumberOfIslandsII/numberOfIslandsII.cc)
+
+add_executable(320
+  leetcode/320-GeneralizedAbbreviation/generalizedAbbreviation.cc)
 
 add_executable(322
         leetcode/322-CoinChange/coinChange.cc)

--- a/leetcode/320-GeneralizedAbbreviation/generalizedAbbreviation.cc
+++ b/leetcode/320-GeneralizedAbbreviation/generalizedAbbreviation.cc
@@ -1,0 +1,118 @@
+#include <vector>
+#include <string>
+#include <stdio.h>
+
+using namespace std;
+
+class Solution {
+public:
+  vector<string> generateAbbreviations(string word) {
+      vector<string> res;
+      vector<int> cand;
+      backtrack(res, cand, word);
+      return res;
+  }  
+private:
+  void backtrack(vector<string>& res, vector<int>& cand, string word) {
+    if (cand.size() == word.length()) {
+      res.push_back(convert2String(cand, word));
+      return;
+    }
+    vector<int> choices = {1, 0};
+    for(auto&& choice: choices) {
+      cand.push_back(choice);
+      backtrack(res, cand, word);
+      cand.pop_back();
+    }
+  }
+
+  // convert2String takes `cand` which is a vector consisting of 0 or 1
+  // and generate new string based on `cand` and given word.
+  string convert2String(vector<int> cand, string word) {
+    // The generation rule:
+    // 凡是0的地方都是原来的字母，单独的1还是1，如果是若干个1连在一起的话，就要求出1的个数，用这个数字来替换对应的字母
+    int cnt = 0;
+    string res = "";
+    for(int i = 0; i < cand.size(); ++i) {
+      if (cand[i] == 1) {
+        cnt++;
+        if (i == word.size() - 1) {
+          res += to_string(cnt);
+        }
+      } else {
+        if (cnt != 0) {
+          res += to_string(cnt);
+          cnt = 0;
+        }
+        res += word[i];
+      }
+    }
+    return res;
+  }
+
+  friend class Test;
+};
+
+using ptr2generateAbbreviations = vector<string> (Solution::*)(string);
+
+class Test {
+public:
+  void test_convert2String() {
+    Solution sol;
+    struct testCase {
+      vector<int> cand;
+      string word;
+      string expected;
+    };
+    vector<testCase> test_cases = {
+      {{0,0,0,0}, "word", "word"},
+      {{0,0,0,1}, "word", "wor1"},
+      {{0,0,1,1}, "word", "wo2"},
+      {{1,1,0,1,1}, "wordz", "2r2"},
+    };
+    for(auto && test_case: test_cases) {
+      string got = (sol.convert2String)(test_case.cand, test_case.word);
+      if (got != test_case.expected) {
+        string cand_str = "[";
+        for(auto && item: test_case.cand) {
+          cand_str += to_string(item);
+          cand_str += ", ";
+        }
+        cand_str += "]";
+        printf("convert2String(%s, %s) = %s \t expected: %s\n",
+               cand_str.c_str(),
+               test_case.word.c_str(),
+               got.c_str(),
+               test_case.expected.c_str());
+      }
+    }
+  }
+
+  void test_pfcn(ptr2generateAbbreviations pfcn) {
+    Solution sol;
+    struct testCase {
+      string word;
+      vector<string> expected;
+    };
+    vector<testCase> test_cases = {
+      {"word", {"word", "1ord", "w1rd", "wo1d", "wor1", "2rd", "w2d", "wo2", "1o1d", "1or1", "w1r1", "1o2", "2r1", "3d", "w3", "4"}},
+      {"exe", {"3","2e","1x1","1xe","e2","e1e","ex1","exe"}}
+    };
+    for(auto && test_case: test_cases) {
+      vector<string> got = (sol.*pfcn)(test_case.word);
+      for(auto&& item: got) {
+        if (find(test_case.expected.begin(), test_case.expected.end(), item) == test_case.expected.end())
+        {
+          assert(false);
+        }
+      }
+    }
+  }    
+};
+
+int main() {
+  Test test;
+  test.test_convert2String();
+  ptr2generateAbbreviations pfcn = &Solution::generateAbbreviations;
+  test.test_pfcn(pfcn);
+}


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->

## Summary

Resolves: [Leetcode 320](https://leetcode.com/problems/generalized-abbreviation/)

## Main Techniques:

Backtracking. The backtracking itself is very standard once you figure out the meaning of "generalized abbreviations of a word". To see an example:

```
0000 word
0001 wor1
0010 wo1d
0011 wo2
0100 w1rd
0101 w1r1
0110 w2d
0111 w3
1000 1ord
1001 1or1
1010 1o1d
1011 1o2
1100 2rd
1101 2r1
1110 3d
1111 4
```

Then the problem becomes generating all the possible `0` and `1` vectors (e.g., `1000`) and convert each vector into the string by following rule:

> 凡是0的地方都是原来的字母，单独的1还是1，如果是若干个1连在一起的话，就要求出1的个数，用这个数字来替换对应的字母

The hint for such observation is that `"word"` has 4 letters and the corresponding "generalized abbreviations" has 16 cases, which is $$2^4$$.

[ref](https://www.cnblogs.com/grandyang/p/5261569.html)

## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 140 ms, faster than 6.63% of C++ online submissions for Generalized Abbreviation.
Memory Usage: 33.9 MB, less than 25.00% of C++ online submissions for Generalized Abbreviation.
```

### Performance Improved Since Last Change
