### PR TITLE
[LC133][C++][DFS][v1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,10 +166,14 @@ add_executable(124
         leetcode/cppinclude/bt.cc)
 
 add_executable(128
-        leetcode/128-LongestConsecutiveSequence/longestConsecutiveSequence.cc)
+  leetcode/128-LongestConsecutiveSequence/longestConsecutiveSequence.cc)
+
+add_executable(133
+  leetcode/133-CloneGraph/cloneGraph.cc
+  leetcode/cppinclude/graph_leetcode.h)
 
 add_executable(140
-        leetcode/140-WordBreakII/wordBreakII.cc)
+  leetcode/140-WordBreakII/wordBreakII.cc)
 
 add_executable(141
         leetcode/141-LinkedListCycle/linkedListCycle.cc

--- a/leetcode/133-CloneGraph/cloneGraph.cc
+++ b/leetcode/133-CloneGraph/cloneGraph.cc
@@ -1,0 +1,53 @@
+// Given a reference of a node in a connected undirected graph, return a deep copy (clone) of the graph. Each node in the graph contains a val (int) and a list (List[Node]) of its neighbors.
+
+// Example:
+
+// Input:
+// {"$id":"1","neighbors":[{"$id":"2","neighbors":[{"$ref":"1"},{"$id":"3","neighbors":[{"$ref":"2"},{"$id":"4","neighbors":[{"$ref":"3"},{"$ref":"1"}],"val":4}],"val":3}],"val":2},{"$ref":"4"}],"val":1}
+
+// Explanation:
+// Node 1's value is 1, and it has two neighbors: Node 2 and 4.
+// Node 2's value is 2, and it has two neighbors: Node 1 and 3.
+// Node 3's value is 3, and it has two neighbors: Node 2 and 4.
+// Node 4's value is 4, and it has two neighbors: Node 1 and 3.
+
+// Note:
+
+//     The number of nodes will be between 1 and 100.
+//     The undirected graph is a simple graph, which means no repeated edges and no self-loops in the graph.
+//     Since the graph is undirected, if node p has node q as neighbor, then node q must have node p as neighbor too.
+//     You must return the copy of the given node as a reference to the cloned graph.
+
+
+#include <vector>
+#include "graph_leetcode.h"
+#include <unordered_map>
+#include <iostream>
+
+using namespace std;
+
+class Solution {
+public:
+    Node* cloneGraph(Node* node) {
+      if (node == nullptr) {
+        return nullptr;
+      }
+      if (marks.find(node) != marks.end()) {
+        return marks[node];
+      }
+      Node* ret = new Node();
+      ret->val = node->val;
+      marks[node] = ret;
+      for(auto&& item: node->neighbors) {
+        ret->neighbors.push_back(cloneGraph(item));
+      }
+      return ret;
+    }
+private:
+    unordered_map<Node*, Node*> marks;
+};
+
+int main() {
+  cout << "No local test for 133-cloneGraph.cc; tested by leetcode\n";  
+  return 0;
+}

--- a/leetcode/cppinclude/graph_leetcode.h
+++ b/leetcode/cppinclude/graph_leetcode.h
@@ -1,0 +1,17 @@
+#include "shared_headers.h"
+
+// Definition for a Node.
+class Node {
+public:
+    int val;
+    std::vector<Node*> neighbors;
+
+    Node() {}
+
+    Node(int _val, std::vector<Node*> _neighbors) {
+        val = _val;
+        neighbors = _neighbors;
+    }
+};
+
+//TODO: add implementation of graph


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->

## Summary

Resolves: [Leetcode 133](https://leetcode.com/problems/clone-graph/)

## Main Techniques:

We use the DFS to clone the graph. One key thing to note is what to store in the `unordered_map`. In the failure attempt, I define `marks` as `unordered_map<int, bool>` with the goal to not revisit (i.e., clone) the node that we have visited (i.e., cloned) before. The goal is right but the usage of `unordered_map` is problematic: we want to avoid revisit but at the same time, we want to put the cloned node to `neighbors` vector of the node we are cloning. Thus, we want to use `unordered_map<Node*, Node*>` to do that.

## Testing

Use Leetcode; no local test infrastructure (e.g., graph implementation) support yet.

## Performance

### Performance Metrics from OJ Platform

```
Runtime: 24 ms, faster than 72.44% of C++ online submissions for Clone Graph.
Memory Usage: 16.5 MB, less than 96.67% of C++ online submissions for Clone Graph.
```

### Performance Improved Since Last Change


## To Learn


## Questions
