### PR TITLE
[LC632][C++][Sliding Window][v1]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 <!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
 <!-- Questions: What questions need further investigation -->
 <!-- Languages: highlight of language usage -->
+<!-- Failure Attempts: failure attempts and lesson learned from those attempts -->
 
 ## Summary
 
@@ -33,3 +34,6 @@ Resolves: [Leetcode #](https://leetcode.com/problems/#)
 
 
 ## Language
+
+
+## Failure Attempts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,16 +432,17 @@ add_executable(567
         leetcode/567-PermutationInString/permutationInString.cc)
 
 add_executable(582
-        leetcode/582-KillProcess/killProcess.cc)
+  leetcode/582-KillProcess/killProcess.cc)
 
 add_executable(609
   leetcode/609-FindDuplicateFileinSystem/findDuplicateFileinSystem.cc)
 
 add_executable(632
-  leetcode/632-SmallestRangeCoveringElementsfromKLists/smallestRangeCoveringElementsfromKLists.cc)      
+  leetcode/632-SmallestRangeCoveringElementsfromKLists/smallestRangeCoveringElementsfromKLists.cc
+  leetcode/cppinclude/cpputility.h)      
 
 add_executable(636
-        leetcode/636-ExclusiveTimeofFunctions/exclusiveTimeofFunctions.cc)
+  leetcode/636-ExclusiveTimeofFunctions/exclusiveTimeofFunctions.cc)
       
 add_executable(658
         leetcode/658-FindKClosestElements/findKClosestElements.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,10 @@ add_executable(582
         leetcode/582-KillProcess/killProcess.cc)
 
 add_executable(609
-        leetcode/609-FindDuplicateFileinSystem/findDuplicateFileinSystem.cc)
+  leetcode/609-FindDuplicateFileinSystem/findDuplicateFileinSystem.cc)
+
+add_executable(632
+  leetcode/632-SmallestRangeCoveringElementsfromKLists/smallestRangeCoveringElementsfromKLists.cc)      
 
 add_executable(636
         leetcode/636-ExclusiveTimeofFunctions/exclusiveTimeofFunctions.cc)

--- a/leetcode/200-NumberOfIslands/numberOfIslands.cc
+++ b/leetcode/200-NumberOfIslands/numberOfIslands.cc
@@ -228,15 +228,15 @@ test(ptr2numIslands pfcn, const char* func_name, bool check_grid)
         // check if the function result is correct
         printf("%s(%s) = %s\n",
                func_name,
-               CPPUtility::matrixStr(grid2).c_str(),
+               CPPUtility::twoDVectorStr(grid2).c_str(),
                to_string(got).c_str());
       }
       if (check_grid && grid2 != test_case.grid) {
         // check if board is modified after invoking function
         printf("%s(%s) modified grid: %s\n",
                func_name,
-               CPPUtility::matrixStr(grid2).c_str(),
-               CPPUtility::matrixStr(test_case.grid).c_str()
+               CPPUtility::twoDVectorStr(grid2).c_str(),
+               CPPUtility::twoDVectorStr(test_case.grid).c_str()
           );
       }
     }

--- a/leetcode/632-SmallestRangeCoveringElementsfromKLists/smallestRangeCoveringElementsfromKLists.cc
+++ b/leetcode/632-SmallestRangeCoveringElementsfromKLists/smallestRangeCoveringElementsfromKLists.cc
@@ -1,10 +1,100 @@
+// You have k lists of sorted integers in ascending order. Find the smallest range that
+// includes at least one number from each of the k lists.
+
+// We define the range [a,b] is smaller than range [c,d] if b-a < d-c or a < c if b-a == d-c
+
+// Example 1:
+// Input: [[4,10,15,24,26], [0,9,12,20], [5,18,22,30]]
+// Output: [20,24]
+// Explanation: 
+// List 1: [4, 10, 15, 24,26], 24 is in range [20,24].
+// List 2: [0, 9, 12, 20], 20 is in range [20,24].
+// List 3: [5, 18, 22, 30], 22 is in range [20,24].
+
+// Note:
+//     The given list may contain duplicates, so ascending order means >= here.
+//     1 <= k <= 3500
+//     -105 <= value of elements <= 105.
+                                                                          
 #include <vector>
+#include <limits>
+#include <stdio.h>
+#include "cpputility.h"
+#include <cassert>
+
+#define FUNC_DEF(func) { func, #func },
 
 using namespace std;
 
 class Solution {
 public:
-    vector<int> smallestRange(vector<vector<int>>& nums) {
-        
+  // WARNING: BRUTE FORCE APPROACH TO ILLUSTRATE IDEA
+  vector<int> smallestRange(vector<vector<int>>& nums) {
+    int minx = 0;
+    int miny = std::numeric_limits<int>::max();
+    for(int i = 0; i < nums.size(); ++i) {
+      for(int j = 0; j < nums[i].size(); ++j) {
+        for(int k = i; k < nums.size(); ++k) {
+          for(int l = (k == i? j: 0); l < nums[k].size(); ++l) {
+            int min = nums[i][j] > nums[k][l] ? nums[k][l] : nums[i][j];
+            int max = nums[i][j] > nums[k][l] ? nums[i][j] : nums[k][l];
+            int n, m;
+            for(m = 0; m < nums.size(); ++m) {
+              for(n = 0; n < nums[m].size(); ++n) {
+                if (nums[m][n] >= min && nums[m][n] <= max) {
+                  break;
+                }
+              }
+              if (n == nums[m].size())
+                break;
+            }
+            if (m == nums.size()) {
+              if (miny - minx > max - min ||
+                  (miny - minx == max -min && minx > min)) {
+                miny = max;
+                minx = min;
+              }
+            }
+          }
+        }
+      }
     }
+    return {minx, miny};
+  }
 };
+
+using ptr2smallestRange = vector<int> (Solution::*)(vector<vector<int>>&);
+
+struct testFuncsInfo {
+  ptr2smallestRange pfcn;
+  const char* pfcn_name;
+};
+
+void test(ptr2smallestRange pfcn, const char* pfcn_name) {
+  Solution sol;
+  struct testCase {
+    vector<vector<int>> nums;
+    vector<int> expected;
+  };
+  vector<testCase> test_cases = {
+    {{{4,10,15,24,26}, {0,9,12,20}, {5,18,22,30}}, {20,24}},
+  };
+  for(auto&& test_case: test_cases) {
+    vector<int> get = (sol.*pfcn)(test_case.nums);
+    if (get != test_case.expected) {
+      printf("%s(%s) = %s\n", pfcn_name,
+             CPPUtility::twoDVectorStr(test_case.nums).c_str(),
+             CPPUtility::oneDVectorStr(get).c_str());
+      assert(false);
+    }
+  }
+}
+
+int main() {
+  vector<testFuncsInfo> func_array = {
+    FUNC_DEF(&Solution::smallestRange)
+  };
+  for(auto&& func : func_array) {
+    test(func.pfcn, func.pfcn_name);
+  }
+}

--- a/leetcode/632-SmallestRangeCoveringElementsfromKLists/smallestRangeCoveringElementsfromKLists.cc
+++ b/leetcode/632-SmallestRangeCoveringElementsfromKLists/smallestRangeCoveringElementsfromKLists.cc
@@ -1,0 +1,10 @@
+#include <vector>
+
+using namespace std;
+
+class Solution {
+public:
+    vector<int> smallestRange(vector<vector<int>>& nums) {
+        
+    }
+};

--- a/leetcode/cppinclude/cpputility.h
+++ b/leetcode/cppinclude/cpputility.h
@@ -19,7 +19,7 @@ namespace CPPUtility
 
   // generate string representation of the given 2D vectors (e.g., matrix)
   template <typename T>
-  std::string matrixStr(std::vector<std::vector<T>> matrix)
+  std::string twoDVectorStr(std::vector<std::vector<T>> matrix)
   {
     std::string cand = "\n[";
     for(int j = 0; j < matrix.size(); ++j)
@@ -40,12 +40,23 @@ namespace CPPUtility
     return cand;
   }
 
-  // pretty print matrix
+  // pretty print 2D vector
   template <typename T>
-  void prettyPrintMatrix(std::ostream& theStream, std::vector<std::vector<T>> matrix)
+  void prettyPrint2DVector(std::ostream& theStream, std::vector<std::vector<T>> matrix)
   {
-    auto rep = matrixStr(matrix);
+    auto rep = twoDVectorStr(matrix);
     theStream << rep;
+  }
+
+  template <typename T>
+  std::string oneDVectorStr(const std::vector<T>& vec) {
+    std::string cand = "[";
+    for(int i = 0; i < vec.size(); ++i) {
+      cand += std::to_string(vec[i]);
+      i != vec.size() - 1 ? cand += "," : cand += "";
+    }
+    cand += "]";
+    return cand;
   }
 }
 

--- a/leetcode/cppinclude/cpputility.h
+++ b/leetcode/cppinclude/cpputility.h
@@ -58,6 +58,20 @@ namespace CPPUtility
     cand += "]";
     return cand;
   }
+
+  // return string representation of vector<pair<T,U>>
+  template <typename T, typename U>
+  std::string oneDVectorPairStr(const std::vector<std::pair<T,U>>& vec) {
+    std::string tmp = "";
+    for(int i = 0; i < vec.size(); ++i) {
+      tmp += "(";
+      tmp += std::to_string(vec[i].first);
+      tmp += ",";
+      tmp += std::to_string(vec[i].second);
+      tmp += ")";
+    }
+    return tmp;
+  }
 }
 
 #endif

--- a/misc/Quora2020/sortdiagonal.cc
+++ b/misc/Quora2020/sortdiagonal.cc
@@ -51,8 +51,8 @@ public:
       sol.sortDiagonal(test_case.matrix);
       if (test_case.matrix != test_case.expected) {
         printf("sortDiagonal(%s) = %s\n",
-               CPPUtility::matrixStr<int>(test_case_cpy).c_str(),
-               CPPUtility::matrixStr<int>(test_case.matrix).c_str());
+               CPPUtility::twoDVectorStr<int>(test_case_cpy).c_str(),
+               CPPUtility::twoDVectorStr<int>(test_case.matrix).c_str());
       }
     }
   }


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->
<!-- Languages: highlight of language usage -->

## Summary

Resolves: [Leetcode 632](https://leetcode.com/problems/smallest-range-covering-elements-from-k-lists/)

## Main Techniques:

We use sliding window / two pointers approach to solve this problem. Let's use the example from problem description to illustrate the idea:

```
[[4,10,15,24,26], [0,9,12,20], [5,18,22,30]]
```

Let's denote each list with label `A`, `B`, and `C` respectively (e.g., `[4,10,15,24,26]` is `A` list; in the actual implementation, we use `int` instead of `char` for list label). Then, the idea is to first merge all the lists together and sorted in ascending order while keeping the list label of each number:

```
(0,B),(4,A),(5,C),(9,B),(10,A),(12,B),(15,A),(18,C),(20,B),(22,C),(24,A),(26,A),(30,C)
```

Then, we use the sliding window approach to find the minimal interval that contains numbers from `A`,`B`,`C` with appearance at least once.  Note that this doesn't indicate the window size is 3 (i.e., number in `A` appears once; number in `B` appears once; number in `C` appears once in the minimal interval. See "Failure Attempts" section for an example).

To find such interval, we use an unordered_map to keep track of the number of appearance of each list label within the window (e.g., `unordered_map<int, int>`; first `int` represents list label). We use two pointers: `left_ptr` and `right_ptr` to do so. We first move `right_ptr` to the end of the sorted list until each list label appears at least once (tracked by `count` in the implementation). Then, we move `left_ptr` to make such interval minimal while maintaining the requirement:

```cpp
while(count == num_lists && left_ptr <= right_ptr) {
//...
```
`count` maintains the number of unique list label appearance in the window and `num_lists` is the number of unique list label (e.g., `3` in this example).

[ref](https://www.cnblogs.com/grandyang/p/7200016.html)

## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 64 ms, faster than 53.35% of C++ online submissions for Smallest Range Covering Elements from K Lists.
Memory Usage: 15.6 MB, less than 50.00% of C++ online submissions for Smallest Range Covering Elements from K Lists.
```

### Performance Improved Since Last Change


## To Learn


## Questions


## Language

We need to highlight the `unordered_map` usage appeared in the implementation:

```
if (m[cand[right_ptr].second] == 0) count++;
```

Normally, we would check the existence of the key in the dictionary first before doing the comparison. However, for `unordered_map` in C++, it is unnecessary.  For [unordered_map operatior \[\]](http://www.cplusplus.com/reference/unordered_map/unordered_map/operator[]/), 

> If k does not match the key of any element in the container, the function inserts a new element with that key and returns a reference to its mapped value. Notice that this always increases the container size by one, even if no mapped value is assigned to the element (the element is constructed using its default constructor).

This means if `cand[right_ptr].second` not exist in `m` (i.e., the unordered_map), then such key will be inserted into `m` first and its value is initialized to the default value (e.g., `init` is `0`; `string` is `""`) and then the comparison is performed. This is much concise than the following:

```cpp
m.emplace(cand[right_ptr].second, 0);
if (m[cand[right_ptr].second] == 0) count++;
```

Another point to highlight is the usage of `pair<int,int>`. Normally, we would think of putting the list label first and the corresponding num the second. However, doing so, we need to implement our own comparator because we want to sort the `vector<pair<int,int>>` by pair's second value:

```
typedef function<bool(pair<int,int>, pair<int,int>)> Comparator;
Comparator comp = [](pair<int,int> item1, pair<int,int> item2) -> bool{
  return item1.second < item2.second;
};
sort(vec.begin(), vec.end(), comp);
```

If we use the first element of pair to represent num and the second element of pair to represent list label, then we can do 

```
sort(vec.begin(), vec.end())
```

This is because, by default, `sort` will sort based on the pair's first element.


## Failure Attempts

The failure attempt shown below makes a mistake by assuming the window size (e.g., `num_lists` aka. `k`) is fixed:

```cpp
class Solution {
public:
  vector<int> smallestRange(vector<vector<int>>& nums) {
    vector<pair<int, int>> cand;
    unordered_map<int, int> m;
    int lower_bound = -100000;
    int upper_bound = 100000;
    int diff = std::numeric_limits<int>::max();
    int num_lists = nums.size();    
    for(int i = 0; i < num_lists; ++i) {
      for(auto&& num: nums[i]) {
        cand.push_back(make_pair(num, i));
      }
      m.emplace(i, 0);
    }
    sort(cand.begin(), cand.end());
    int left_ptr = 0;
    int count = 0;
    if (cand.size() == num_lists) {
      return {cand[0].first, cand[num_lists-1].first};
    }
    for(left_ptr = 0; left_ptr <= cand.size() - num_lists; ++left_ptr) {
      for(int j = left_ptr; j < left_ptr + num_lists; ++j) {
        if (m[cand[j].second] == 0) {
          count++;
          m[cand[j].second]++;          
        }
      }
      if (count == num_lists) {
        int interval_diff = cand[left_ptr+num_lists-1].first - cand[left_ptr].first;
        if ( interval_diff < diff || (interval_diff == diff && cand[left_ptr].first < lower_bound)) {
          lower_bound = cand[left_ptr].first;
          upper_bound = cand[left_ptr+num_lists-1].first;
          diff = interval_diff;
        } 
      }
      m[cand[left_ptr].second]--;
      if (m[cand[left_ptr].second] == 0) count--;
    }
    return {lower_bound, upper_bound};
  }
};
```

To see why this doesn't work, consider the following example:

```
[[0,14],[10,12,13],[11]]
```

If we apply the idea of solving the problem explained above, we will have:

```
(0,A), (10,B), (11,C),(12,B),(13,B),(14,A)
```

If we use the fixed windows size, the result we will have is `[0,11]` (obtained from `(0,A),(10,B),(11,C)`) but the actual right answer is `[11,14]` (obtained from `(11,C),(12,B),(13,B),(14,A)`)
