### PR TITLE
[LC76][C++][Sliding Window][v1]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@
 <!-- Performance: Performance measures about the solution -->
 <!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
 <!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
+<!-- Implementation Tricks: Engineering/Implementation tricks -->
 <!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
 <!-- Questions: What questions need further investigation -->
 <!-- Languages: highlight of language usage -->
@@ -26,6 +27,7 @@ Resolves: [Leetcode #](https://leetcode.com/problems/#)
 
 ### Performance Improved Since Last Change
 
+## Implementation Tricks
 
 ## To Learn
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@
 <!-- Performance: Performance measures about the solution -->
 <!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
 <!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
+<!-- Implementation Notice: places where we should be careful during implementation; places that are easy to make mistakes -->
 <!-- Implementation Tricks: Engineering/Implementation tricks -->
 <!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
 <!-- Questions: What questions need further investigation -->
@@ -26,6 +27,8 @@ Resolves: [Leetcode #](https://leetcode.com/problems/#)
 ### Performance Metrics from OJ Platform
 
 ### Performance Improved Since Last Change
+
+## Implementation Notice
 
 ## Implementation Tricks
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,19 +109,23 @@ add_executable(54
         leetcode/54-SpiralMatrix/spiralMatrix.cc)
 
 add_executable(62
-        leetcode/62-UniquePaths/uniquePaths.cc)
+  leetcode/62-UniquePaths/uniquePaths.cc)
 
 add_executable(78
-        leetcode/78-Subsets/subsets.cc)
+  leetcode/78-Subsets/subsets.cc)
 
 add_executable(70
-        leetcode/70-ClimbingStairs/climbingStairs.cc)
+  leetcode/70-ClimbingStairs/climbingStairs.cc)
 
+add_executable(76
+  leetcode/76-MinimumWindowSubstring/minimumWindowSubstring.cc
+  leetcode/cppinclude/cpputility.h)
+      
 add_executable(77
-        leetcode/77-Combinations/combinations.cc)
+  leetcode/77-Combinations/combinations.cc)
       
 add_executable(88
-        leetcode/88-MergeSortedArray/mergeSortedArray.cc)
+  leetcode/88-MergeSortedArray/mergeSortedArray.cc)
 
 add_executable(95
         leetcode/95-UniqueBinarySearchTreesII/uniqueBinarySearchTreesII.cc)

--- a/leetcode/76-MinimumWindowSubstring/minimumWindowSubstring.cc
+++ b/leetcode/76-MinimumWindowSubstring/minimumWindowSubstring.cc
@@ -1,0 +1,76 @@
+#include<string>
+#include<unordered_map>
+#include<vector>
+
+using namespace std;
+
+#define FUNC_DEF(func) { func, #func },
+
+class Solution {
+public:
+  string minWindow(string s, string t) {
+    string res = "";
+    int lower_bound, upper_bound;
+    unordered_map<char, int> char_count;
+    int diff = s.length();
+    for(auto&& ch : t) {
+        char_count[ch]++;
+    }
+    int left_ptr = 0;
+    int count = 0;
+    for(int right_ptr = 0; right_ptr < s.length(); ++right_ptr) {
+      if (--char_count[s[right_ptr]] >= 0) count++;
+      while(count == t.length()) {
+          int interval_diff = right_ptr - left_ptr + 1;
+          if (interval_diff < diff) {
+              lower_bound = left_ptr;
+              upper_bound = right_ptr;
+          }
+          if (++char_count[s[left_ptr]] > 0) count--;
+          left_ptr++;
+      }
+    }
+    for(int i = lower_bound; i <= upper_bound; ++i) {
+        res += s[i];
+    }
+    return res;
+  }
+};
+
+using ptr2minWindow = string (Solution::*)(string, string);
+
+struct testFuncsInfo {
+  ptr2minWindow pfcn;
+  const char* pfcn_name;
+};
+
+void test(ptr2minWindow pfcn, const char* pfcn_name) {
+  Solution sol;
+  struct testCase {
+    string s;
+    string t;
+    string expected;
+  };
+  vector<testCase> test_cases = {
+    {"ADOBECODEBANC", "ABC", "BANC"},
+  };
+  for(auto&& test_case: test_cases) {
+    string got = (sol.*pfcn)(test_case.s, test_case.t);
+    if (got != test_case.expected) {
+      printf("%s(%s, %s) = %s\n", pfcn_name,
+             test_case.s.c_str(),
+             test_case.t.c_str(),
+             got.c_str());
+      assert(false);
+    }
+  }
+}
+
+int main() {
+  vector<testFuncsInfo> func_array = {
+    FUNC_DEF(&Solution::minWindow)
+  };
+  for(auto&& func : func_array) {
+    test(func.pfcn, func.pfcn_name);
+  }
+}

--- a/leetcode/76-MinimumWindowSubstring/minimumWindowSubstring.cc
+++ b/leetcode/76-MinimumWindowSubstring/minimumWindowSubstring.cc
@@ -1,6 +1,7 @@
 #include<string>
 #include<unordered_map>
 #include<vector>
+#include<limits>
 
 using namespace std;
 
@@ -9,15 +10,14 @@ using namespace std;
 class Solution {
 public:
   string minWindow(string s, string t) {
-    string res = "";
+    string res;
     int lower_bound, upper_bound;
     unordered_map<char, int> char_count;
-    int diff = s.length();
+    int diff = numeric_limits<int>::max();
     for(auto&& ch : t) {
         char_count[ch]++;
     }
-    int left_ptr = 0;
-    int count = 0;
+    int left_ptr = 0, count = 0;
     for(int right_ptr = 0; right_ptr < s.length(); ++right_ptr) {
       if (--char_count[s[right_ptr]] >= 0) count++;
       while(count == t.length()) {
@@ -25,6 +25,7 @@ public:
           if (interval_diff < diff) {
               lower_bound = left_ptr;
               upper_bound = right_ptr;
+              diff = interval_diff;
           }
           if (++char_count[s[left_ptr]] > 0) count--;
           left_ptr++;
@@ -53,6 +54,8 @@ void test(ptr2minWindow pfcn, const char* pfcn_name) {
   };
   vector<testCase> test_cases = {
     {"ADOBECODEBANC", "ABC", "BANC"},
+    {"a", "a", "a"},
+    {"cabwefgewcwaefgcf", "cae", "cwae"},
   };
   for(auto&& test_case: test_cases) {
     string got = (sol.*pfcn)(test_case.s, test_case.t);


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->
<!-- Languages: highlight of language usage -->
<!-- Failure Attempts: failure attempts and lesson learned from those attempts -->

## Summary

Resolves: [Leetcode 76](https://leetcode.com/problems/minimum-window-substring/)

## Main Techniques:

This problem uses the same approach as [LC632](https://github.com/xxks-kkk/shuati/pull/145). The rest is implementation tricks and notice. 

## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 16 ms, faster than 67.12% of C++ online submissions for Minimum Window Substring.
Memory Usage: 10 MB, less than 86.00% of C++ online submissions for Minimum Window Substring.
```

### Performance Improved Since Last Change

## Implementation Notice

The following places we should be careful:

- `int diff = numeric_limits<int>::max();`: Always set `dif` to `INT_MAX`. Sometimes, you might want to be smart and set it to `s.length()` but that will not work. For example, the case `s = "a"` and `t = "a"`

- `int interval_diff = right_ptr - left_ptr + 1;`: remember to `+1` during the calculation of interval length

- `diff = interval_diff;`: remember to update `diff`

## Implementation Tricks

The key place to note is how we check when to move `left_ptr`. Naive attempt may be that we maintain a separate `unordered_map` to keep track of the characters we encounter in `s` (denoted as `m`) and we check whether the `unordered_map` for letter appearance in `t` (denoted as `standard`) is the "submap" of `m`, meaning that all the key-value pairs in `standard` match exactly with key-value pairs in `m`. This is very expensive operation as in each iteration of the for loop, when we need to perform such check, we need to iterate through all the key-value pairs in `standard`.

How can we do better? In the actual implementation, we do: 

```cpp
unordered_map<char, int> char_count;
//...
for(auto&& ch : t) {
  char_count[ch]++;
}
//...
  if (--char_count[s[right_ptr]] >= 0) count++;
  while(count == t.length()) {
     //...
     if (++char_count[s[left_ptr]] > 0) count--;
     //...
  }
//...
```

The idea here is that for all the letters appeared in `t`, their value in `char_count` will be greater than 0.  Then, during the loop when we walk through letters in `s`, if `--char_count[s[right_ptr]] >= 0`, that means such letter appeared in `t` because `for(auto&& ch: t)` block makes letter in `t` has positive value in map at the beginning and when we decrement such value, the result is nonnegative. Thus, we increment `count`, which is used to keep track of whether we have seen all the letters in `t` so far. For letters not appeared in `t`, `--char_count[s[right_ptr]]` will be negative as they are not inside `char_count` at first, then inserted into the map, and then decremented by 1. When we move `left_ptr` to the right, we do `++char_count[s[left_ptr]]`. For letters in `s` not appeared in `t`, this operation will make value in the map become 0 because it is negative due to `--char_count[s[right_ptr]]`. However, for letters in `s` that is also in `t`, such operation will make value in the map positive (inside the `while` loop, 
`count == t.length()` holds and due to the decrement operation, such value will be `0` before the increment operation). This means we should `count--` because we lose one letter that appeared in `t` from the current window (letters appeared in `[left_ptr, right_ptr]`).

Use example `S = "ADOBECODEBANC"` and `T = "ABC"` to understand.

[ref](https://www.cnblogs.com/grandyang/p/4340948.html)

## To Learn


## Questions


## Language


## Failure Attempts

The failure comes from trying to compare `m` with `standard`, two unordered_maps, which will very unlikely to be true.

```cpp
class Solution {
public:
    string minWindow(string s, string t) {
        string res = "";
        int lower_bound, upper_bound;
        unordered_map<char, int> m;
        unordered_map<char, int> standard;
        int diff = s.length();
        for(auto&& ch : t) {
            standard[ch]++;
        }
        int left_ptr = 0;
        for(int right_ptr = 0; right_ptr < s.length(); ++right_ptr) {
            m[s[right_ptr]]++;
            while(m == standard && left_ptr <= right_ptr) {
                int interval_diff = right_ptr - left_ptr;
                if (interval_diff < diff) {
                    lower_bound = left_ptr;
                    upper_bound = right_ptr;
                }
                m[s[left_ptr]]--;
                left_ptr++;
            }
        }
        for(int i = lower_bound; i <= upper_bound; ++i) {
            res += s[i];
        }
        return res;
    }
};
```
