### PR TITLE
[LC505][C++][DFS/BFS/Dijkstra][v1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,16 +424,19 @@ add_executable(443
         leetcode/443-StringCompression/stringCompression.cc)
 
 add_executable(451
-        leetcode/451-SortCharactersByFrequency/sortCharactersByFrequency.cc)
+  leetcode/451-SortCharactersByFrequency/sortCharactersByFrequency.cc)
 
 add_executable(460
-        leetcode/460-LFUCache/lFUCache.cc)
+  leetcode/460-LFUCache/lFUCache.cc)
 
 add_executable(463
-        leetcode/463-IslandPerimeter/islandPerimeter.cc)
+  leetcode/463-IslandPerimeter/islandPerimeter.cc)
+
+add_executable(505
+  leetcode/505-TheMazeII/theMazeII.cc)
 
 add_executable(567
-        leetcode/567-PermutationInString/permutationInString.cc)
+  leetcode/567-PermutationInString/permutationInString.cc)
 
 add_executable(582
   leetcode/582-KillProcess/killProcess.cc)

--- a/leetcode/505-TheMazeII/theMazeII.cc
+++ b/leetcode/505-TheMazeII/theMazeII.cc
@@ -53,6 +53,11 @@ private:
 
 using ptr2shortestDistance = int (Solution::*)(vector<vector<int>>&, vector<int>&, vector<int>&);
 
+struct testFuncsInfo {
+  ptr2shortestDistance pfcn;
+  const char* pfcn_name;
+};
+
 void test(ptr2shortestDistance pfcn, const char* pfcn_name) {
   Solution sol;
   struct testCase {
@@ -88,6 +93,10 @@ void test(ptr2shortestDistance pfcn, const char* pfcn_name) {
 }
 
 int main() {
-  ptr2shortestDistance pfcn = &Solution::shortestDistance;
-  test(pfcn, FUNC_DEF_NAME(&Solution::shortestDistance));
+  vector<testFuncsInfo> func_array = {
+    FUNC_DEF(&Solution::shortestDistance)
+  };
+  for(auto&& func : func_array) {
+    test(func.pfcn, func.pfcn_name);
+  }
 }

--- a/leetcode/505-TheMazeII/theMazeII.cc
+++ b/leetcode/505-TheMazeII/theMazeII.cc
@@ -3,37 +3,50 @@
 
 using namespace std;
 
-class Solution {
+class Solution
+{
 public:
   // DFS Approach (TLE)
-  int shortestDistance(vector<vector<int>>& maze, vector<int>& start, vector<int>& destination) {
-    if (maze.empty() || maze[0].empty()) return -1;
-    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point [i][j] from start
+  int shortestDistance(vector<vector<int>> &maze, vector<int> &start,
+                       vector<int> &destination)
+  {
+    if (maze.empty() || maze[0].empty())
+      return -1;
+    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point
+    // [i][j] from start
     vector<vector<int>> shortestDistanceAtPointTable(maze.size(), vector<int>(maze[0].size(), INT_MAX));
     shortestDistanceAtPointTable[start[0]][start[1]] = 0;
-    vector<pair<int,int>> dirs = {{0,1}, {0,-1}, {1,0}, {-1,0}};
+    vector<pair<int, int>> dirs = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
     shortestDistanceFromPoint(maze, start, destination, shortestDistanceAtPointTable, dirs);
     int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
     return res == INT_MAX ? -1 : res;
   }
 
-  // BFS Approach 
-  int shortestDistance2(vector<vector<int>>& maze, vector<int>& start, vector<int>& destination) {
-    if (maze.empty() || maze[0].empty()) return -1;
+  // BFS Approach
+  int shortestDistance2(vector<vector<int>> &maze, vector<int> &start,
+                        vector<int> &destination)
+  {
+    if (maze.empty() || maze[0].empty())
+      return -1;
     int m = maze.size(), n = maze[0].size();
-    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point [i][j] from start    
+    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point
+    // [i][j] from start
     vector<vector<int>> shortestDistanceAtPointTable(m, vector<int>(n, INT_MAX));
     queue<pair<int, int>> q;
-    vector<pair<int,int>> dirs = {{0,1}, {0,-1}, {1,0}, {-1,0}};
+    vector<pair<int, int>> dirs = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
     shortestDistanceAtPointTable[start[0]][start[1]] = 0;
     q.push({start[0], start[1]});
-    while (!q.empty()) {
-      auto coord = q.front(); q.pop();
-      for (auto&& dir: dirs) {
+    while (!q.empty())
+    {
+      auto coord = q.front();
+      q.pop();
+      for (auto &&dir : dirs)
+      {
         int start_x = coord.first;
         int start_y = coord.second;
         int dist = shortestDistanceAtPointTable[start_x][start_y];
-        while (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && maze[start_x][start_y] != 1) {
+        while (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && maze[start_x][start_y] != 1)
+        {
           start_x += dir.first;
           start_y += dir.second;
           dist++;
@@ -41,36 +54,84 @@ public:
         start_x -= dir.first;
         start_y -= dir.second;
         dist--;
-        if (dist < shortestDistanceAtPointTable[start_x][start_y]) {
+        if (dist < shortestDistanceAtPointTable[start_x][start_y])
+        {
           shortestDistanceAtPointTable[start_x][start_y] = dist;
-          if (start_x != destination[0] || start_y != destination[1]) q.push({start_x, start_y});
+          if (start_x != destination[0] || start_y != destination[1])
+            q.push({start_x, start_y});
         }
       }
     }
     int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
-    return  res == INT_MAX ? -1 : res;
+    return res == INT_MAX ? -1 : res;
   }
-  
+
+  // Dijkstra's algorithm
+  int shortestDistance3(vector<vector<int>> &maze, vector<int> &start,
+                        vector<int> &destination)
+  {
+    int m = maze.size(), n = maze[0].size();
+    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point [i][j] from start
+    vector<vector<int>> shortestDistanceAtPointTable(m, vector<int>(n, INT_MAX));
+    vector<pair<int, int>> dirs = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
+    auto cmp = [](vector<int> &a, vector<int> &b) { return a[2] > b[2]; };
+    priority_queue<vector<int>, vector<vector<int>>, decltype(cmp)> pq(cmp);
+    pq.push({start[0], start[1], 0});
+    shortestDistanceAtPointTable[start[0]][start[1]] = 0;
+    while (!pq.empty())
+    {
+      auto coord = pq.top();
+      pq.pop();
+      for (auto &&dir : dirs)
+      {
+        int start_x = coord[0];
+        int start_y = coord[1];
+        int dist = shortestDistanceAtPointTable[start_x][start_y];
+        while (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && maze[start_x][start_y] != 1)
+        {
+          start_x += dir.first;
+          start_y += dir.second;
+          ++dist;
+        }
+        start_x -= dir.first;
+        start_y -= dir.second;
+        --dist;
+        if (dist < shortestDistanceAtPointTable[start_x][start_y])
+        {
+          shortestDistanceAtPointTable[start_x][start_y] = dist;
+          if (start_x != destination[0] || start_y != destination[1])
+            pq.push({start_x, start_y, dist});
+        }
+      }
+    }
+    int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
+    return (res == INT_MAX) ? -1 : res;
+  }
+
 private:
-  void shortestDistanceFromPoint(vector<vector<int>>& maze,
-                                 vector<int>& start,
-                                 vector<int>& destination,
-                                 vector<vector<int>>& shortestDistanceAtPointTable,
-                                 const vector<pair<int,int>>& dirs) {
+  void shortestDistanceFromPoint(
+      vector<vector<int>> &maze, vector<int> &start, vector<int> &destination,
+      vector<vector<int>> &shortestDistanceAtPointTable,
+      const vector<pair<int, int>> &dirs)
+  {
     int m = maze.size();
     int n = maze[0].size();
     int start_x = start[0];
     int start_y = start[1];
-    //printf("start_x: %d, start_y: %d \n %s\n", start_x, start_y, CPPUtility::twoDVectorStr<int>(shortestDistanceAtPointTable).c_str());
-    if (start == destination) {
+    // printf("start_x: %d, start_y: %d \n %s\n", start_x, start_y,
+    // CPPUtility::twoDVectorStr<int>(shortestDistanceAtPointTable).c_str());
+    if (start == destination)
+    {
       // Don't do: shortesDistanceAtPointTable[start_x][start_y] = 0;
       return;
     }
-    for (auto&& dir: dirs) {
+    for (auto &&dir : dirs)
+    {
       start_x = start[0];
       start_y = start[1];
       int dist = shortestDistanceAtPointTable[start_x][start_y];
-      while (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && maze[start_x][start_y] != 1) {
+      while (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && maze[start_x][start_y] != 1)
+      {
         start_x += dir.first;
         start_y += dir.second;
         dist++;
@@ -78,7 +139,8 @@ private:
       start_x -= dir.first;
       start_y -= dir.second;
       dist--;
-      if (dist < shortestDistanceAtPointTable[start_x][start_y]) {
+      if (dist < shortestDistanceAtPointTable[start_x][start_y])
+      {
         shortestDistanceAtPointTable[start_x][start_y] = dist;
         vector<int> v = {start_x, start_y};
         shortestDistanceFromPoint(maze, v, destination, shortestDistanceAtPointTable, dirs);
@@ -87,53 +149,66 @@ private:
   }
 };
 
-using ptr2shortestDistance = int (Solution::*)(vector<vector<int>>&, vector<int>&, vector<int>&);
+using ptr2shortestDistance = int (Solution::*)(vector<vector<int>> &, vector<int> &, vector<int> &);
 
-struct testFuncsInfo {
+struct testFuncsInfo
+{
   ptr2shortestDistance pfcn;
-  const char* pfcn_name;
+  const char *pfcn_name;
 };
 
-void test(ptr2shortestDistance pfcn, const char* pfcn_name) {
+void test(ptr2shortestDistance pfcn, const char *pfcn_name)
+{
   Solution sol;
-  struct testCase {
+  struct testCase
+  {
     vector<vector<int>> maze;
     vector<int> start;
     vector<int> destination;
     int expected;
   };
   vector<testCase> test_cases = {
-    {{{0,0,1,0,0},
-      {0,0,0,0,0},
-      {0,0,0,1,0},
-      {1,1,0,1,1},
-      {0,0,0,0,0}}, {0,4}, {4,4}, 12},
-    {{{0,0,1,0,0},
-      {0,0,0,0,0},
-      {0,0,0,1,0},
-      {1,1,0,1,1},
-      {0,0,0,0,0}}, {0,4}, {3,2}, -1},    
+      {{{0, 0, 1, 0, 0},
+        {0, 0, 0, 0, 0},
+        {0, 0, 0, 1, 0},
+        {1, 1, 0, 1, 1},
+        {0, 0, 0, 0, 0}},
+       {0, 4},
+       {4, 4},
+       12},
+      {{{0, 0, 1, 0, 0},
+        {0, 0, 0, 0, 0},
+        {0, 0, 0, 1, 0},
+        {1, 1, 0, 1, 1},
+        {0, 0, 0, 0, 0}},
+       {0, 4},
+       {3, 2},
+       -1},
   };
-  for(auto&& test_case: test_cases) {
-    int got = (sol.*pfcn)(test_case.maze, test_case.start, test_case.destination);
-    if (got != test_case.expected) {
-      printf("%s(%s,%s,%s) = %d\n",
-             pfcn_name,
+  for (auto &&test_case : test_cases)
+  {
+    int got =
+        (sol.*pfcn)(test_case.maze, test_case.start, test_case.destination);
+    if (got != test_case.expected)
+    {
+      printf("%s(%s,%s,%s) = %d\n", pfcn_name,
              CPPUtility::twoDVectorStr(test_case.maze).c_str(),
              CPPUtility::oneDVectorStr(test_case.start).c_str(),
-             CPPUtility::oneDVectorStr(test_case.destination).c_str(),
-             got);
+             CPPUtility::oneDVectorStr(test_case.destination).c_str(), got);
       assert(false);
     }
   }
 }
 
-int main() {
+int main()
+{
   vector<testFuncsInfo> func_array = {
     FUNC_DEF(&Solution::shortestDistance)
     FUNC_DEF(&Solution::shortestDistance2)
+    FUNC_DEF(&Solution::shortestDistance3)
   };
-  for(auto&& func : func_array) {
+  for (auto &&func : func_array)
+  {
     test(func.pfcn, func.pfcn_name);
   }
 }

--- a/leetcode/505-TheMazeII/theMazeII.cc
+++ b/leetcode/505-TheMazeII/theMazeII.cc
@@ -1,0 +1,93 @@
+#include "cpputility.h"
+
+using namespace std;
+
+class Solution {
+public:
+  // DFS Approach (TLE)
+  int shortestDistance(vector<vector<int>>& maze, vector<int>& start, vector<int>& destination) {
+    if (maze.empty() || maze[0].empty()) return -1;
+    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point [i][j] from start
+    vector<vector<int>> shortestDistanceAtPointTable(maze.size(), vector<int>(maze[0].size(), INT_MAX));
+    shortestDistanceAtPointTable[start[0]][start[1]] = 0;
+    vector<pair<int,int>> dirs = {{0,1}, {0,-1}, {1,0}, {-1,0}};
+    shortestDistanceFromPoint(maze, start, destination, shortestDistanceAtPointTable, dirs);
+    int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
+    return res == INT_MAX ? -1 : res;
+  }
+private:
+  void shortestDistanceFromPoint(vector<vector<int>>& maze,
+                                 vector<int>& start,
+                                 vector<int>& destination,
+                                 vector<vector<int>>& shortestDistanceAtPointTable,
+                                 const vector<pair<int,int>>& dirs) {
+    int m = maze.size();
+    int n = maze[0].size();
+    int start_x = start[0];
+    int start_y = start[1];
+    //printf("start_x: %d, start_y: %d \n %s\n", start_x, start_y, CPPUtility::twoDVectorStr<int>(shortestDistanceAtPointTable).c_str());
+    if (start == destination) {
+      // Don't do: shortesDistanceAtPointTable[start_x][start_y] = 0;
+      return;
+    }
+    for (auto&& dir: dirs) {
+      start_x = start[0];
+      start_y = start[1];
+      int dist = shortestDistanceAtPointTable[start_x][start_y];
+      while (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && maze[start_x][start_y] != 1) {
+        start_x += dir.first;
+        start_y += dir.second;
+        dist++;
+      }
+      start_x -= dir.first;
+      start_y -= dir.second;
+      dist--;
+      if (dist < shortestDistanceAtPointTable[start_x][start_y]) {
+        shortestDistanceAtPointTable[start_x][start_y] = dist;
+        vector<int> v = {start_x, start_y};
+        shortestDistanceFromPoint(maze, v, destination, shortestDistanceAtPointTable, dirs);
+      }
+    }
+  }
+};
+
+using ptr2shortestDistance = int (Solution::*)(vector<vector<int>>&, vector<int>&, vector<int>&);
+
+void test(ptr2shortestDistance pfcn, const char* pfcn_name) {
+  Solution sol;
+  struct testCase {
+    vector<vector<int>> maze;
+    vector<int> start;
+    vector<int> destination;
+    int expected;
+  };
+  vector<testCase> test_cases = {
+    {{{0,0,1,0,0},
+      {0,0,0,0,0},
+      {0,0,0,1,0},
+      {1,1,0,1,1},
+      {0,0,0,0,0}}, {0,4}, {4,4}, 12},
+    {{{0,0,1,0,0},
+      {0,0,0,0,0},
+      {0,0,0,1,0},
+      {1,1,0,1,1},
+      {0,0,0,0,0}}, {0,4}, {3,2}, -1},    
+  };
+  for(auto&& test_case: test_cases) {
+    int got = (sol.*pfcn)(test_case.maze, test_case.start, test_case.destination);
+    if (got != test_case.expected) {
+      printf("%s(%s,%s,%s) = %d\n",
+             pfcn_name,
+             CPPUtility::twoDVectorStr(test_case.maze).c_str(),
+             CPPUtility::oneDVectorStr(test_case.start).c_str(),
+             CPPUtility::oneDVectorStr(test_case.destination).c_str(),
+             got);
+      assert(false);
+    }
+  }
+}
+
+int main() {
+  ptr2shortestDistance pfcn = &Solution::shortestDistance;
+  test(pfcn, FUNC_DEF_NAME(&Solution::shortestDistance));
+}

--- a/leetcode/505-TheMazeII/theMazeII.cc
+++ b/leetcode/505-TheMazeII/theMazeII.cc
@@ -1,4 +1,5 @@
 #include "cpputility.h"
+#include <queue>
 
 using namespace std;
 
@@ -15,6 +16,41 @@ public:
     int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
     return res == INT_MAX ? -1 : res;
   }
+
+  // BFS Approach 
+  int shortestDistance2(vector<vector<int>>& maze, vector<int>& start, vector<int>& destination) {
+    if (maze.empty() || maze[0].empty()) return -1;
+    int m = maze.size(), n = maze[0].size();
+    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point [i][j] from start    
+    vector<vector<int>> shortestDistanceAtPointTable(m, vector<int>(n, INT_MAX));
+    queue<pair<int, int>> q;
+    vector<pair<int,int>> dirs = {{0,1}, {0,-1}, {1,0}, {-1,0}};
+    shortestDistanceAtPointTable[start[0]][start[1]] = 0;
+    q.push({start[0], start[1]});
+    while (!q.empty()) {
+      auto coord = q.front(); q.pop();
+      for (auto&& dir: dirs) {
+        int start_x = coord.first;
+        int start_y = coord.second;
+        int dist = shortestDistanceAtPointTable[start_x][start_y];
+        while (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && maze[start_x][start_y] != 1) {
+          start_x += dir.first;
+          start_y += dir.second;
+          dist++;
+        }
+        start_x -= dir.first;
+        start_y -= dir.second;
+        dist--;
+        if (dist < shortestDistanceAtPointTable[start_x][start_y]) {
+          shortestDistanceAtPointTable[start_x][start_y] = dist;
+          if (start_x != destination[0] || start_y != destination[1]) q.push({start_x, start_y});
+        }
+      }
+    }
+    int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
+    return  res == INT_MAX ? -1 : res;
+  }
+  
 private:
   void shortestDistanceFromPoint(vector<vector<int>>& maze,
                                  vector<int>& start,
@@ -95,6 +131,7 @@ void test(ptr2shortestDistance pfcn, const char* pfcn_name) {
 int main() {
   vector<testFuncsInfo> func_array = {
     FUNC_DEF(&Solution::shortestDistance)
+    FUNC_DEF(&Solution::shortestDistance2)
   };
   for(auto&& func : func_array) {
     test(func.pfcn, func.pfcn_name);


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- Implementation Notice: places where we should be careful during implementation; places that are easy to make mistakes -->
<!-- Implementation Tricks: Engineering/Implementation tricks -->
<!-- To Do: what left to be done -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->
<!-- Languages: highlight of language usage -->
<!-- Failure Attempts: failure attempts and lesson learned from those attempts -->

## Summary

Resolves: [Leetcode 505](https://leetcode.com/problems/the-maze-ii/)

## Main Techniques:

Very standard DFS, BFS approach. Now, let's briefly talk about Dijkstra's algorithm approach.

Dijkstra's algorithm is used to solve single-source shortest-path with positive weighted edges. This problem can be treated as a weighted graph with all the weights equal to one. The modification to the BFS is mainly to use min heap instead of queue: we choose vertex with the smallest distance from the start to such vertex among all the unvisited vertices (see MAW p296 bottom).

[ref](https://www.cnblogs.com/grandyang/p/6725380.html)

## Testing


## Performance

### Performance Metrics from OJ Platform

- DFS (`shortestDistance`)

Time Limit Exceeded

- BFS (`shortestDistance2`)

```
Runtime: 32 ms, faster than 93.17% of C++ online submissions for The Maze II.
Memory Usage: 13.4 MB, less than 100.00% of C++ online submissions for The Maze II.
```

- Dijkstra's Algorithm (`shortestDistance3`)

```
Runtime: 44 ms, faster than 65.47% of C++ online submissions for The Maze II.
Memory Usage: 15 MB, less than 100.00% of C++ online submissions for The Maze II.
```

### Performance Improved Since Last Change

## Implementation Notice

- `vector<vector<int>> shortestDistanceAtPointTable(m, vector<int>(n, INT_MAX));` represents: `shortestDistanceAtPointTable[i][j]` = shortest distance to reach point [i][j] from` start`. Then the answer is `shortestDistanceAtPointTable[destination[0]][destination[1]]`. One tempting idea is to let `shortestDistanceAtPointTable[i][j]` represents the shortest distance from point [i][j] to the `destination`. This idea intuitively can work but since we need to have `INT_MAX` for initalization; `-1` for impossible distance  (i.e., no such path) from point[i][j] to the destination; and the actual shortest distance from point[i][j] to the destination. Maintaining three values in the table is very hard and requires additional effort. In fact, the idea is the same as treating `shortestDistanceAtPointTable[i][j]` as the shortest distance to reach point [i][j] from` start`: effectively, now the `destination` becomes the start point and `start` becomes destination.
One extra remark on the definition of `shortestDistanceAtPointTable[i][j]`: MAW p.296, d_v is defined the same way as here.

- If you compare implementation with LC 490 (#153), we see that there is no place we set `maze[start[0]][start[1]] = -1` and we don't check whether maze cell is visited or not; the only place we check is `if (dist < shortestDistanceAtPointTable[start_x][start_y]) { //... }`. This is correct because in fact, we check maze cell is visited or not implicitly by comparing `dist` with `shortestDistanceAtPointTable[start_x][start_y]`. The reasoning is that suppose `dist` starts with `3` (i.e., `int dist = shortestDistanceAtPointTable[start_x][start_y];` sets 3 to dist) and after 5 steps we reach a point B with 10 as an entry in table. By the implementation, since 8 < 10 and we will update the B's entry in table to 8. Suppose we will revisit B again, since we have additional positive steps (denote as X), then 8+X > 8 and the `if` condition will fail. Thus, we will never revisit the same maze cell again in the recursive call but as you might notice, we may waste effort to chase path that will fail ultimately.

- **(DFS)** The following code seems correct but is actually wrong. The reason is that once `start` is equal to `destination`, it is not necessarily the shortest distance to reach `start` from given starting point (passed in as parameter) is `0`. 

```cpp
if (start == destination) {
      shortesDistanceAtPointTable[start_x][start_y] = 0; // WRONG!
      return;
}
```

## Implementation Tricks

## To Do

- Dijkstra's algorithm blog post

## To Learn


## Questions


## Language

The following code snippet shows how to implement a min heap with `vector<int>` as an element:

```cpp
auto cmp = [](vector<int> &a, vector<int> &b) { return a[2] > b[2]; };
priority_queue<vector<int>, vector<vector<int>>, decltype(cmp)> pq(cmp);
```

Note:

- For min heap, we use `>` in the comparator function body
- `vector<vector<int>>` is the container we choose to implement the min heap [ref](http://www.cplusplus.com/reference/queue/priority_queue/)

## Failure Attempts
