### PR TITLE
[LC675][C++][BFS][v1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,38 +455,42 @@ add_executable(636
   leetcode/636-ExclusiveTimeofFunctions/exclusiveTimeofFunctions.cc)
       
 add_executable(658
-        leetcode/658-FindKClosestElements/findKClosestElements.cpp)
+  leetcode/658-FindKClosestElements/findKClosestElements.cpp)
 
 add_executable(662
-        leetcode/662-MaximumWidthOfBinaryTree/maximumWidthOfBinaryTree.cc
-        leetcode/cppinclude/bt.cc)
+  leetcode/662-MaximumWidthOfBinaryTree/maximumWidthOfBinaryTree.cc
+  leetcode/cppinclude/bt.cc)
 
 add_executable(663
-        leetcode/663-EqualTreePartition/equalTreePartition.cc
-        leetcode/cppinclude/bt.cc)
+  leetcode/663-EqualTreePartition/equalTreePartition.cc
+  leetcode/cppinclude/bt.cc)
 
 add_executable(669
-        leetcode/669-TrimaBinarySearchTree/trimaBinarySearchTree.cc
-        leetcode/cppinclude/bt.cc
-        leetcode/cppinclude/bst.cc)
+  leetcode/669-TrimaBinarySearchTree/trimaBinarySearchTree.cc
+  leetcode/cppinclude/bt.cc
+  leetcode/cppinclude/bst.cc)
 
+add_executable(675
+  leetcode/675-CutOffTreesforGolfEvent/cutOffTreesforGolfEvent.cc
+  leetcode/cppinclude/cpputility.h)
+        
 add_executable(704
-        leetcode/704-BinarySearch/binarySearch.cc)
+  leetcode/704-BinarySearch/binarySearch.cc)
 
 add_executable(739
-        leetcode/739-DailyTemperatures/dailyTemperatures.cc)
+  leetcode/739-DailyTemperatures/dailyTemperatures.cc)
 
 add_executable(784
-        leetcode/784-LetterCasePermutation/letterCasePermutation.cc)
+  leetcode/784-LetterCasePermutation/letterCasePermutation.cc)
 
 add_executable(796
-        leetcode/796-RotateString/rotateString.cc)
+  leetcode/796-RotateString/rotateString.cc)
 
 add_executable(797
-        leetcode/797-AllPathsFromSourceToTarget/allPathsFromSourceToTarget.cc)
+  leetcode/797-AllPathsFromSourceToTarget/allPathsFromSourceToTarget.cc)
 
 add_executable(811
-        leetcode/811-SubdomainVisitCount/subdomainVisitCount.cc)
+  leetcode/811-SubdomainVisitCount/subdomainVisitCount.cc)
 
 add_executable(829
         leetcode/829-ConsecutiveNumbersSum/consecutiveNumbersSum.cc)

--- a/leetcode/675-CutOffTreesforGolfEvent/cutOffTreesforGolfEvent.cc
+++ b/leetcode/675-CutOffTreesforGolfEvent/cutOffTreesforGolfEvent.cc
@@ -10,69 +10,66 @@ public:
   {
     if (forest.empty() || forest[0].empty())
       return 0;
-    auto comp = [](vector<int> &a, vector<int> &b) { return a[2] > b[2]; };
-    priority_queue<vector<int>, vector<vector<int>>, decltype(comp)> pq(comp);
-    queue<vector<int>> starts;
-    starts.push({0,0});
     int dist = 0;
     int m = forest.size(), n = forest[0].size();
-    for (int i = 0; i < m; ++i)
-    {
-      for (int j = 0; j < n; ++j)
-      {
+    vector<int> start = {0, 0};
+    
+    // {height, i, j}
+    vector<tuple<int, int, int>> trees;
+    for (int i = 0; i < m; ++i) {
+      for (int j = 0; j < n; ++j) {
         if (forest[i][j] != 0) {
-          pq.push({i, j, forest[i][j]});          
+          trees.push_back({forest[i][j], i, j});
         }
       }
     }
-    while(!pq.empty()) {
-      auto q = pq.top(); pq.pop();
-      vector<int> destination = {q[0], q[1]};
-      auto start = starts.front(); starts.pop();
+    sort(trees.begin(), trees.end());
+    
+    for(int i = 0; i < trees.size(); ++i) {
+      vector<int> destination = {get<1>(trees[i]), get<2>(trees[i])};
       int shortestPath = findShortestPath(forest, start, destination);
-      if (shortestPath == -1) return -1;
+      if (shortestPath == INT_MAX) return -1;
       else dist += shortestPath;
-      starts.push(destination);
+      start = destination;
     }
     return dist;
   }
 private:
+  // min steps go from `start` to `destination`
   int findShortestPath(vector<vector<int>>& forest,
                         vector<int>& start,
                         vector<int>& destination) {
-    int m = forest.size(), n = forest.size();
-    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point
-    // [i][j] from start
-    vector<vector<int>> shortestDistanceAtPointTable(m, vector<int>(n, INT_MAX));
+    int m = forest.size(), n = forest[0].size();
     queue<pair<int, int>> q;
     vector<pair<int, int>> dirs = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
-    shortestDistanceAtPointTable[start[0]][start[1]] = 0;
-    q.push({start[0], start[1]});
-    while (!q.empty())
-    {
-      auto coord = q.front();
-      q.pop();
-      for (auto &&dir : dirs)
-      {
+    auto visited = vector<vector<int>>(m, vector<int>(n, 0));
+    q.emplace(start[0], start[1]);
+    int dist = 0;
+    while (!q.empty()) {
+      int num_nodes_for_current_level = q.size();
+      while(num_nodes_for_current_level--) {
+        auto coord = q.front(); q.pop();
         int start_x = coord.first;
         int start_y = coord.second;
-        int dist = shortestDistanceAtPointTable[start_x][start_y];
-        start_x += dir.first;
-        start_y += dir.second;
-        if (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && forest[start_x][start_y] != 0)
-        {
-          dist++;
-          if (dist < shortestDistanceAtPointTable[start_x][start_y])
-          {
-            shortestDistanceAtPointTable[start_x][start_y] = dist;
-            if (start_x != destination[0] || start_y != destination[1])
-              q.push({start_x, start_y});
+        if (start_x == destination[0] && start_y == destination[1])
+          return dist;        
+        for (auto &&dir : dirs) {
+          start_x = coord.first;
+          start_y = coord.second;        
+          start_x += dir.first;
+          start_y += dir.second;
+          if (start_x >= 0 && start_x < m &&
+              start_y >= 0 && start_y < n &&
+              forest[start_x][start_y] != 0 &&
+              visited[start_x][start_y] != 1) {
+            q.emplace(start_x, start_y);
+            visited[start_x][start_y] = 1;
           }
         }
       }
+      dist++;
     }
-    int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
-    return res == INT_MAX ? -1 : res;    
+    return INT_MAX;
   }
 };
 

--- a/leetcode/675-CutOffTreesforGolfEvent/cutOffTreesforGolfEvent.cc
+++ b/leetcode/675-CutOffTreesforGolfEvent/cutOffTreesforGolfEvent.cc
@@ -1,0 +1,111 @@
+#include "cpputility.h"
+#include <queue>
+
+using namespace std;
+
+class Solution
+{
+public:
+  int cutOffTree(vector<vector<int>> &forest)
+  {
+    if (forest.empty() || forest[0].empty())
+      return 0;
+    auto comp = [](vector<int> &a, vector<int> &b) { return a[2] > b[2]; };
+    priority_queue<vector<int>, vector<vector<int>>, decltype(comp)> pq(comp);
+    queue<vector<int>> starts;
+    starts.push({0,0});
+    int dist = 0;
+    int m = forest.size(), n = forest[0].size();
+    for (int i = 0; i < m; ++i)
+    {
+      for (int j = 0; j < n; ++j)
+      {
+        if (forest[i][j] != 0) {
+          pq.push({i, j, forest[i][j]});          
+        }
+      }
+    }
+    while(!pq.empty()) {
+      auto q = pq.top(); pq.pop();
+      vector<int> destination = {q[0], q[1]};
+      auto start = starts.front(); starts.pop();
+      int shortestPath = findShortestPath(forest, start, destination);
+      if (shortestPath == -1) return -1;
+      else dist += shortestPath;
+      starts.push(destination);
+    }
+    return dist;
+  }
+private:
+  int findShortestPath(vector<vector<int>>& forest,
+                        vector<int>& start,
+                        vector<int>& destination) {
+    int m = forest.size(), n = forest.size();
+    // shortestDistanceAtPointTable[i][j] = shortest distance to reach point
+    // [i][j] from start
+    vector<vector<int>> shortestDistanceAtPointTable(m, vector<int>(n, INT_MAX));
+    queue<pair<int, int>> q;
+    vector<pair<int, int>> dirs = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
+    shortestDistanceAtPointTable[start[0]][start[1]] = 0;
+    q.push({start[0], start[1]});
+    while (!q.empty())
+    {
+      auto coord = q.front();
+      q.pop();
+      for (auto &&dir : dirs)
+      {
+        int start_x = coord.first;
+        int start_y = coord.second;
+        int dist = shortestDistanceAtPointTable[start_x][start_y];
+        start_x += dir.first;
+        start_y += dir.second;
+        if (start_x >= 0 && start_x < m && start_y >= 0 && start_y < n && forest[start_x][start_y] != 0)
+        {
+          dist++;
+          if (dist < shortestDistanceAtPointTable[start_x][start_y])
+          {
+            shortestDistanceAtPointTable[start_x][start_y] = dist;
+            if (start_x != destination[0] || start_y != destination[1])
+              q.push({start_x, start_y});
+          }
+        }
+      }
+    }
+    int res = shortestDistanceAtPointTable[destination[0]][destination[1]];
+    return res == INT_MAX ? -1 : res;    
+  }
+};
+
+using ptr2cutOffTree = int (Solution::*)(vector<vector<int>> &);
+
+void test(ptr2cutOffTree pfcn, const char *pfcn_name)
+{
+  Solution sol;
+  struct testCase
+  {
+    vector<vector<int>> forest;
+    int expected;
+  };
+  vector<testCase> test_cases = {
+    {{{1, 7, 2}, {0, 0, 5}, {8, 3, 6}}, 16},
+    {{{9,7,2}, {0,0,5}, {8,3,6}}, 22},
+  };
+  for (auto &&test_case : test_cases)
+  {
+    int got = (sol.*pfcn)(test_case.forest);
+    if (got != test_case.expected)
+    {
+      printf("%s(%s) = %d\n",
+             pfcn_name,
+             CPPUtility::twoDVectorStr<int>(test_case.forest).c_str(),
+             got);
+      assert(false);
+    }
+  }
+}
+
+int main()
+{
+  ptr2cutOffTree pfcn = &Solution::cutOffTree;
+  test(pfcn, FUNC_DEF_NAME(&Solution::cutOffTree));
+}


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- Implementation Notice: places where we should be careful during implementation; places that are easy to make mistakes -->
<!-- Implementation Tricks: Engineering/Implementation tricks -->
<!-- To Do: what left to be done -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->
<!-- Languages: highlight of language usage -->
<!-- Failure Attempts: failure attempts and lesson learned from those attempts -->

## Summary

Resolves: [Leetcode 675](https://leetcode.com/problems/cut-off-trees-for-golf-event/)

## Main Techniques:

The problem requires us to cut off all the trees in this forest in the order of tree's height - always cut off the tree with lowest height first. In addition, we will start from the point (0, 0). This means if (0,0)'s tree height is 9 and there is a tree with height 1, then we need to first walk to tree with height 1 and cut it first and then revisit back to (0,0) sometime later. This makes problem looks extremely similar to LC505 (#154): we first sort the trees by their heights in the ascending order and then we find the shortest path distance between the current position we are standing and the about-to-cut tree's position. In other words, we repeatedly call BFS asking for shortest distance between two points (like we did with LC505) until either cut all trees (return the total distance we traveled) or -1 if we cannot cut certain tree in the middle point.

## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 496 ms, faster than 66.92% of C++ online submissions for Cut Off Trees for Golf Event.
Memory Usage: 154.6 MB, less than 25.00% of C++ online submissions for Cut Off Trees for Golf Event.
```

### Performance Improved Since Last Change

## Implementation Notice

This example shows a classic implementation of BFS:

- We need to use `visited` to keep track of which node we have visited so far
- We need to keep track of the current level queue size (e.g., `num_nodes_for_current_level`) so that we know when we can increment level (i.e., nodes in the same level have distance with the start point): once the nodes in the current level are processed, we increment level (e.g., `num_nodes_for_current_level`)
- We check whether the current node popped from the queue is actually the destination before we pushing the neighbor unvisited nodes onto the queue. This is a very easy mistake to make:

```cpp 
if (start_x == destination[0] && start_y == destination[1])
          return dist;
```
- We mark the neighbor node visited immediately when we push them to the queue. The motivation is that if we mark the node visited when we pop the node from the queue, then we can potentially push multiple node to the queue: if a node is reachable by more than one node in the current level.


[ref](http://zxi.mytechroad.com/blog/searching/leetcode-675-cut-off-trees-for-golf-event/)

## Implementation Tricks

Since `sort` is based on the first element of holding data structure (e.g., first element of tuple or first element of pair), we can avoid writing our own comparator by placing the tree height as the first element in the tuple. We use the same trick in #145.

## To Do

## To Learn


## Questions


## Language

We use `tuple` in the implementation:

```cpp
vector<tuple<int, int, int>> trees;
vector<int> destination = {get<1>(trees[i]), get<2>(trees[i])}; // Access tuple element with get<1>()
```

To push `pair<int,int>` to the queue, we can either use `q.emplace(start_x, start_y);` or `q.push({start_x, start_y})`. The former one can avoid typing `{` and `}`

## Failure Attempts

I got [idea right](https://github.com/xxks-kkk/shuati/pull/155/commits/be6f28b3fb70d91cb4f39eb3fdc47160e710a543#diff-b59689d7a05817e183b89d6281bc3873) but I hit heap overflow in OJ:

- No need to use `priority_queue` to sort the trees; simple `sort` works fine
- We don't need to use `shortestDistanceAtPointTable` to maintain the distance from the start point to all the other nodes
- We can use early stop by comparing node popped from the queue with the destination