### PR TITLE
[LC1114][C++][Semaphore/Conditional Variable][v1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,36 +493,39 @@ add_executable(811
   leetcode/811-SubdomainVisitCount/subdomainVisitCount.cc)
 
 add_executable(829
-        leetcode/829-ConsecutiveNumbersSum/consecutiveNumbersSum.cc)
+  leetcode/829-ConsecutiveNumbersSum/consecutiveNumbersSum.cc)
 
 add_executable(842
-        leetcode/842-SplitArrayintoFibonacciSequence/splitArrayintoFibonacciSequence.cc)
+  leetcode/842-SplitArrayintoFibonacciSequence/splitArrayintoFibonacciSequence.cc)
 
 add_executable(977
-        leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc)
+  leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc)
+
+add_executable(1114
+  leetcode/1114-PrintInOrder/printInOrder.cc)      
       
 add_executable(00
-        leetcode/cppinclude/queue.tpp
-        leetcode/cppinclude/queue.h
-        misc/QueueArrayImplementation/queueArrayImplementation.cc)
+  leetcode/cppinclude/queue.tpp
+  leetcode/cppinclude/queue.h
+  misc/QueueArrayImplementation/queueArrayImplementation.cc)
 
 add_executable(001
-        misc/GetFruits/getFruits.cc)
+  misc/GetFruits/getFruits.cc)
 
 add_executable(002
-        misc/HDRT/simplePrint.c)
+  misc/HDRT/simplePrint.c)
 
 add_executable(003
-        misc/ReformattingDates/reformattingDates.cc)
+  misc/ReformattingDates/reformattingDates.cc)
 
 add_executable(004
-        misc/MaximizingProfitFromStocks/maximizingProfitFromStocks.cc)
+  misc/MaximizingProfitFromStocks/maximizingProfitFromStocks.cc)
 
 add_executable(005
-        misc/IsThisATree/isThisATree.cc)
+  misc/IsThisATree/isThisATree.cc)
 
 add_executable(006
-        misc/FindTheWinner/findTheWinner.cc)
+  misc/FindTheWinner/findTheWinner.cc)
 
 add_executable(007
         misc/SmartSale/smartSale.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,8 @@ add_executable(977
   leetcode/977-SquaresofaSortedArray/squaresofaSortedArray.cc)
 
 add_executable(1114
-  leetcode/1114-PrintInOrder/printInOrder.cc)      
+  leetcode/1114-PrintInOrder/printInOrder.cc
+  leetcode/cppinclude/mysemaphore.cc)      
       
 add_executable(00
   leetcode/cppinclude/queue.tpp

--- a/leetcode/1114-PrintInOrder/printInOrder.cc
+++ b/leetcode/1114-PrintInOrder/printInOrder.cc
@@ -3,12 +3,12 @@
 #include <functional>
 #include <iostream>
 #include <mutex>
-#include <semaphore.h>
 #include <sstream>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include "mysemaphore.h"
 
 using namespace std;
 
@@ -26,38 +26,6 @@ void printThird()
 {
   cout << "third" << std::flush;
 }
-
-class Semaphore
-{
-  size_t avail;
-  std::mutex m;
-  std::condition_variable cv;
-
-public:
-  /** Default constructor. Default semaphore is a binary semaphore **/
-  explicit Semaphore(size_t avail_ = 1) : avail(avail_) {}
-
-  void wait()
-  {
-    std::unique_lock<std::mutex> lk(m);
-    cv.wait(lk, [this] { return avail > 0; });
-    avail--;
-    lk.unlock();
-  }
-
-  void post()
-  {
-    m.lock();
-    avail++;
-    m.unlock();
-    cv.notify_one();
-  }
-
-  size_t available() const
-  {
-    return avail;
-  }
-};
 
 class Foo
 {

--- a/leetcode/1114-PrintInOrder/printInOrder.cc
+++ b/leetcode/1114-PrintInOrder/printInOrder.cc
@@ -59,13 +59,12 @@ public:
   }
 };
 
-Semaphore firstJobDone(0);
-Semaphore secondJobDone(0);
-
 class Foo
 {
+  Semaphore firstJobDone;
+  Semaphore secondJobDone;
 public:
-  Foo() {}
+  Foo(): firstJobDone(0), secondJobDone(0) {}
 
   void first(function<void()> printFirst)
   {
@@ -115,7 +114,8 @@ void test()
     vector<thread> threads;
     for (int i = 0; i < 3; ++i)
     {
-      threads.emplace_back(m[test_case.input[i]].first, foo, m[test_case.input[i]].second);
+      // We use the same object across multiple threads
+      threads.emplace_back(m[test_case.input[i]].first, ref(foo), m[test_case.input[i]].second);
     }
     for (auto &&th : threads)
     {

--- a/leetcode/1114-PrintInOrder/printInOrder.cc
+++ b/leetcode/1114-PrintInOrder/printInOrder.cc
@@ -7,21 +7,27 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <mutex>
 
 using namespace std;
 
+mutex some_mutex;
+
 void printFirst()
 {
+  lock_guard<mutex> guard(some_mutex);
   cout << "first" << std::flush;
 }
 
 void printSecond()
 {
+  lock_guard<mutex> guard(some_mutex);
   cout << "second" << std::flush;
 }
 
 void printThird()
 {
+  lock_guard<mutex> guard(some_mutex);
   cout << "third" << std::flush;
 }
 
@@ -85,7 +91,7 @@ void test()
     vector<thread> threads;
     for (int i = 0; i < 3; ++i)
     {
-      threads.emplace_back(m[i+1].first, foo, m[i+1].second);
+      threads.emplace_back(m[test_case.input[i]].first, foo, m[test_case.input[i]].second);
     }
     for (auto &&th : threads)
     {

--- a/leetcode/1114-PrintInOrder/printInOrder.cc
+++ b/leetcode/1114-PrintInOrder/printInOrder.cc
@@ -1,0 +1,109 @@
+#include "cpputility.h"
+#include <functional>
+#include <iostream>
+#include <semaphore.h>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+using namespace std;
+
+void printFirst()
+{
+  cout << "first" << std::flush;
+}
+
+void printSecond()
+{
+  cout << "second" << std::flush;
+}
+
+void printThird()
+{
+  cout << "third" << std::flush;
+}
+
+class Foo
+{
+protected:
+  sem_t firstJobDone;
+  sem_t secondJobDone;
+
+public:
+  Foo()
+  {
+    sem_init(&firstJobDone, 0, 0);
+    sem_init(&secondJobDone, 0, 0);
+  }
+
+  void first(function<void()> printFirst)
+  {
+    // printFirst() outputs "first". Do not change or remove this line.
+    printFirst();
+    sem_post(&firstJobDone);
+  }
+
+  void second(function<void()> printSecond)
+  {
+    sem_wait(&firstJobDone);
+    // printSecond() outputs "second". Do not change or remove this line.
+    printSecond();
+    sem_post(&secondJobDone);
+  }
+
+  void third(function<void()> printThird)
+  {
+    sem_wait(&secondJobDone);
+    // printThird() outputs "third". Do not change or remove this line.
+    printThird();
+  }
+};
+
+void test()
+{
+  unordered_map<int, pair<void (Foo::*)(function<void()>), function<void()>>> m({
+      {1, {&Foo::first, printFirst}},
+      {2, {&Foo::second, printSecond}},
+      {3, {&Foo::third, printThird}},
+  });
+  struct testCase
+  {
+    vector<int> input;
+    string expected;
+  };
+  vector<testCase> test_cases = {
+      {{1, 2, 3}, "firstsecondthird"},
+      {{1, 3, 2}, "firstsecondthird"},
+  };
+  for (auto &&test_case : test_cases)
+  {
+    std::stringstream buffer;
+    std::streambuf *old = std::cout.rdbuf(buffer.rdbuf());
+    Foo foo;
+    vector<thread> threads;
+    for (int i = 0; i < 3; ++i)
+    {
+      threads.emplace_back(m[i+1].first, foo, m[i+1].second);
+    }
+    for (auto &&th : threads)
+    {
+      th.join();
+    }
+    auto got = buffer.str();
+    if (got != test_case.expected)
+    {
+      printf("input: %s = %s\n",
+             CPPUtility::oneDVectorStr<int>(test_case.input).c_str(),
+             got.c_str());
+      assert(false);
+    }
+    std::cout.rdbuf(old);
+  }
+}
+
+int main()
+{
+  test();
+}

--- a/leetcode/1114-PrintInOrder/printInOrder.cc
+++ b/leetcode/1114-PrintInOrder/printInOrder.cc
@@ -105,5 +105,8 @@ void test()
 
 int main()
 {
-  test();
+  for(int i = 0; i < 10; ++i) {
+    // Test repeatedly to detect any potential race condition
+    test();    
+  }
 }

--- a/leetcode/cppinclude/mysemaphore.cc
+++ b/leetcode/cppinclude/mysemaphore.cc
@@ -1,0 +1,23 @@
+#include "mysemaphore.h"
+
+
+void
+Semaphore::wait()
+{
+  std::unique_lock<std::mutex> lk(m);
+  cv.wait(lk, [this] { return avail > 0; });
+  avail--;
+}
+
+void
+Semaphore::post()
+{
+  std::unique_lock<std::mutex> lk(m);
+  avail++;
+  cv.notify_one();
+}
+
+int
+Semaphore::available() const {
+  return avail;
+}

--- a/leetcode/cppinclude/mysemaphore.cc
+++ b/leetcode/cppinclude/mysemaphore.cc
@@ -17,7 +17,7 @@ Semaphore::post()
   cv.notify_one();
 }
 
-int
+size_t
 Semaphore::available() const {
   return avail;
 }

--- a/leetcode/cppinclude/mysemaphore.h
+++ b/leetcode/cppinclude/mysemaphore.h
@@ -5,16 +5,16 @@
 
 class Semaphore {
 private:
-  int avail;
+  size_t avail;
   std::mutex m;
   std::condition_variable cv;
 
 public:
   /** Default constructor. Default semaphore is a binary semaphore **/  
-  explicit Semaphore(int avail_ = 1) : avail(avail_) {}
+  explicit Semaphore(size_t avail_ = 1) : avail(avail_) {}
   void wait();
   void post();
-  int available() const;
+  size_t available() const;
 };
 
 #endif //MYSEMAPHORE_H

--- a/leetcode/cppinclude/mysemaphore.h
+++ b/leetcode/cppinclude/mysemaphore.h
@@ -1,0 +1,20 @@
+#ifndef MYSEMAPHORE_H
+#define MYSEMAPHORE_H
+
+#include "shared_headers.h"
+
+class Semaphore {
+private:
+  int avail;
+  std::mutex m;
+  std::condition_variable cv;
+
+public:
+  /** Default constructor. Default semaphore is a binary semaphore **/  
+  explicit Semaphore(int avail_ = 1) : avail(avail_) {}
+  void wait();
+  void post();
+  int available() const;
+};
+
+#endif //MYSEMAPHORE_H

--- a/leetcode/cppinclude/shared_headers.h
+++ b/leetcode/cppinclude/shared_headers.h
@@ -19,5 +19,7 @@
 #include <iterator>
 #include <fstream>
 #include <set>
+#include <mutex>
+#include <condition_variable>
 
 #endif //SHUATI_SHARED_HEADERS_H


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- Implementation Notice: places where we should be careful during implementation; places that are easy to make mistakes -->
<!-- Implementation Tricks: Engineering/Implementation tricks -->
<!-- To Do: what left to be done -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->
<!-- Languages: highlight of language usage -->
<!-- Failure Attempts: failure attempts and lesson learned from those attempts -->

## Summary

Resolves: [Leetcode 1114](https://leetcode.com/problems/print-in-order/)

## Main Techniques:

See post: 

## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 152 ms, faster than 61.93% of C++ online submissions for Print in Order.
Memory Usage: 9.1 MB, less than 100.00% of C++ online submissions for Print in Order.
```

### Performance Improved Since Last Change

## Implementation Notice

- Test code contains a commonly-seen pattern on spawning new threads and wait for all of them. See https://github.com/xxks-kkk/snippets/pull/2

## Implementation Tricks

- Compared to redirect stdout to string in #149, we further improve the code by realizing [std::cout.rdbuf](http://www.cplusplus.com/reference/ios/ios/rdbuf/) returns 

>  A pointer to the stream buffer object associated with the stream before the call.

In other words, unlike #149 implementation, we don't need to save the old internal buffer of `cout` (e.g., `std::streambuf *coutbuf = std::cout.rdbuf();`) and restore the old internal buffer using it at the end (e.g., `std::cout.rdbuf(coutbuf);`). Instead, we can directly use the return of `std::cout.rdbuf` when we set the new internal buffer:

```cpp
std::stringstream buffer;
std::streambuf *old = std::cout.rdbuf(buffer.rdbuf());
// Do the work
std::cout.rdbuf(old);
```
[ref](https://stackoverflow.com/questions/5419356/redirect-stdout-stderr-to-a-string)

## To Do

## To Learn


## Questions


## Language

-  In the test implementation, we start thread with non static member function ([ref](https://thispointer.com/c11-start-thread-by-member-function-with-arguments/)):

```cpp
threads.emplace_back(m[test_case.input[i]].first, ref(foo), m[test_case.input[i]].second);
```

This statement essentially starts threads based on the function mapping stored in `m`. To make it easy look, one of the thread it created is:

```cpp
Foo foo;
thread t1(&Foo::first, ref(foo), printFirst); // ignore `ref` for now
```

To see other ways of creating threads, [see here](http://www.cplusplus.com/reference/thread/thread/) for the most basic case and [see here](https://thispointer.com/c-11-multithreading-part-1-three-different-ways-to-create-threads/) for more complex situation.

- `std::ref` needs to use if we want to share the object across multiple threads ( [ref](https://stackoverflow.com/questions/34078208/passing-object-by-reference-to-stdthread-in-c11/34078246)). Without `ref` in `ref(foo)`, the object get copied to each thread and a compilation error will be triggered:

```
/Library/Developer/CommandLineTools/usr/include/c++/v1/type_traits:2362:12: error: call to implicitly-deleted copy constructor of
      'typename decay<Foo &>::type' (aka 'Foo')
    return _VSTD::forward<_Tp>(__t);
<-- snip -->
/Users/zyh/Documents/projects/shuati/leetcode/1114-PrintInOrder/printInOrder.cc:33:14: note: copy constructor of 'Semaphore' is implicitly deleted because
      field 'm' has an inaccessible copy constructor
  std::mutex m;
```

The reason for such compilation error is that copy constructor for `mutex` is deleted (i.e., `mutex` should not be copied) and since we create thread by copying `Foo` object and since `Semaphore` class objects are created within `Foo`, `mutex` within `Semaphore` will be copied as well, which is bad because copy constructor for `mutex` has already been deleted. As indicated by root cause analysis, another way we can proceed is to copy the `Foo` object when create the threads and modify the `Foo` class implementation by moving `Semaphore` object construction out of `Foo` class and initialized globally as shown [here](https://github.com/xxks-kkk/shuati/blob/bc6a68015087d3bf734327ba307a2e23d5bea13c/leetcode/1114-PrintInOrder/printInOrder.cc#L62). 

Personally, I think this makes sense by moving `Semaphore` construction out of `Foo` class and generally applicable but in this specific situation, it is also acceptable to contain `Semaphore` within `Foo` class as shown by other LC solutions.

- We can initialize `unordered_map` like below ([ref](https://thispointer.com/different-ways-to-initialize-an-unordered_map/):

```cpp
  unordered_map<int, pair<void (Foo::*)(function<void()>), function<void()>>> m({
      {1, {&Foo::first, printFirst}},
      {2, {&Foo::second, printSecond}},
      {3, {&Foo::third, printThird}},
  });
```

- Language features used to implement semaphore can be seen in the post


## Failure Attempts
