### PR TITLE
[LC75][C++][Misc][v1]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ target
 go.test
 venv
 target_list.txt
+env/

--- a/leetcode/75-SortColors/sortColors.cc
+++ b/leetcode/75-SortColors/sortColors.cc
@@ -6,11 +6,11 @@ using namespace std;
 class Solution {
 public:
     void sortColors(vector<int>& nums) {
-      // invariant:
+      // keep the following invariant during the partitioning:
       // bottom: [0, smaller)
       // equal: [smaller, equal)
       // unclassified: [equal, larger)
-      // larger: [larger, nums.size())
+      // top: [larger, nums.size())
       int smaller = 0, equal = 0, larger = nums.size();
       int pivot = 1;
       while (equal < larger) {

--- a/leetcode/75-SortColors/sortColors.cc
+++ b/leetcode/75-SortColors/sortColors.cc
@@ -1,0 +1,55 @@
+#include<vector>
+#include "cpputility.h"
+
+using namespace std;
+
+class Solution {
+public:
+    void sortColors(vector<int>& nums) {
+      // invariant:
+      // bottom: [0, smaller)
+      // equal: [smaller, equal)
+      // unclassified: [equal, larger)
+      // larger: [larger, nums.size())
+      int smaller = 0, equal = 0, larger = nums.size();
+      int pivot = 1;
+      while (equal < larger) {
+        if (nums[equal] < pivot) {
+          swap(nums[smaller++], nums[equal++]);
+        } else if (nums[equal] == pivot) {
+          equal++;
+        } else {
+          swap(nums[equal], nums[--larger]);
+        }
+      }
+    }
+};
+
+using ptr2sortColors = void (Solution::*)(vector<int>&);
+
+void test(ptr2sortColors pfcn) {
+  Solution sol;
+  struct testCase {
+    vector<int> nums;
+    vector<int> expected;
+  };
+  vector<testCase> test_cases = {
+    {{2,0,2,1,1,0}, {0,0,1,1,2,2}}
+  };
+  for(auto&& test_case: test_cases) {
+    vector<int> nums_copy(test_case.nums);
+    (sol.*pfcn)(test_case.nums);
+    if (test_case.nums != test_case.expected) {
+      printf("%s(%s) -> %s\n",
+             "sortColors",
+             CPPUtility::oneDVectorStr<int>(nums_copy).c_str(),
+             CPPUtility::oneDVectorStr<int>(test_case.nums).c_str());
+      assert(false);
+    }
+  }  
+}
+
+int main() {
+  ptr2sortColors pfcn = &Solution::sortColors;
+  test(pfcn);
+}

--- a/leetcode/CMakeLists.txt
+++ b/leetcode/CMakeLists.txt
@@ -95,6 +95,12 @@ target_include_directories(56 PRIVATE ${INCLUDE_DIR}/cppinclude)
 add_executable(62
   62-UniquePaths/uniquePaths.cc)
 
+add_executable(75
+  75-SortColors/sortColors.cc
+  ${INCLUDE_DIR}/cppinclude/cpputility.h)
+target_include_directories(75 PRIVATE ${INCLUDE_DIR}/cppinclude)
+add_test(NAME sortColors.cc COMMAND 75)
+
 add_executable(78
   78-Subsets/subsets.cc)
 


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Runtime Complexity Analysis -->
<!-- Space Complexity Analysis -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- Implementation Notice: places where we should be careful during implementation; places that are easy to make mistakes -->
<!-- Implementation Tricks: Engineering/Implementation tricks -->
<!-- To Do: what left to be done -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->
<!-- Languages: highlight of language usage -->
<!-- Failure Attempts: failure attempts and lesson learned from those attempts -->

## Summary

Resolves: [Leetcode 75](https://leetcode.com/problems/sort-colors/)

## Main Techniques:

This is the same question as EPI 5.1 The Dutch National Flag Problem. The idea is to classify item in `nums` into items less than, equal to, and greater than the pivot (in Leetcode problem setup, the pivot is fixed to 1) in a single pass. We do this by maintaining four subarrays: *bottom* (items less than pivot), *middle* (items equal to pivot), *unclassified*, and *top* (elements greater than pivot). Initially, all elements are in *unclassfied*. We iterate through items in *unclassfied*, and move items into one of *bottom*, *middle*, and *top* groups according to the relative order between the incoming unclassified element and the pviot.

The above algorithm will terminate because the number of unclassified elements reduced by one in each case. The algorithm is correct because item pointed by `smaller` and items before it will always be classified: we only move `smaller` when there is an item that is smaller than `pivot`. 

## Runtime Complexity Analysis


## Space Complexity Analysis


## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 4 ms, faster than 69.90% of C++ online submissions for Sort Colors.
Memory Usage: 8.6 MB, less than 84.21% of C++ online submissions for Sort Colors.
```

### Performance Improved Since Last Change

## Implementation Notice

Note that we advance `equal` when `nums[equal] < pivot` and we **don't** advance `equal` when `nums[equal] > pivot`. The reason is because once swap `nums[equal]` and `nums[--larger]`, we don't know the relative order between `nums[--larger]` and `pivot`.  Thus, after swap, we still need to check `nums[equal]`, which is now has item that was originally `nums[--larger]`. However, for the `smaller` case, we can advance `equal` because by the invariant, `nums[smaller]` is equal to the pivot and we don't need to check again.

## Implementation Tricks

## To Do

## To Learn


## Questions


## Language


## Failure Attempts
