### PR TITLE
[LC716][C++][Stack][v1]

### DIFF
--- a/leetcode/716-MaxStack/maxStack.cc
+++ b/leetcode/716-MaxStack/maxStack.cc
@@ -1,0 +1,86 @@
+#include <stack>
+
+using namespace std;
+
+class MaxStack
+{
+public:
+  /** initialize your data structure here. */
+  MaxStack()
+  {
+  }
+
+  void push(int x)
+  {
+    element_with_cached_max_.emplace(ElementWithCachedMax{x, element_with_cached_max_.empty() ? x : peekMax()});
+  }
+
+  int pop()
+  {
+    int pop_element = element_with_cached_max_.top().element;
+    element_with_cached_max_.pop();
+    return pop_element;
+  }
+
+  int top()
+  {
+    return element_with_cached_max_.top().element;
+  }
+
+  int peekMax()
+  {
+    return element_with_cached_max_.top().max;
+  }
+
+  int popMax()
+  {
+    stack<ElementWithCachedMax> buffer;
+    while (element_with_cached_max_.top().element != element_with_cached_max_.top().max)
+    {
+      buffer.emplace(element_with_cached_max_.top());
+      element_with_cached_max_.pop();
+    }
+    int pop_max = element_with_cached_max_.top().element;
+    element_with_cached_max_.pop();
+    while (!buffer.empty())
+    {
+      element_with_cached_max_.emplace(buffer.top());
+      buffer.pop();
+    }
+    return pop_max;
+  }
+
+private:
+  struct ElementWithCachedMax
+  {
+    int element, max;
+  };
+  stack<ElementWithCachedMax> element_with_cached_max_;
+};
+
+void test() {
+  MaxStack* stack = new MaxStack();
+  stack->push(5);
+  stack->push(1);
+  stack->push(5);
+  assert(stack->top() == 5);
+  assert(stack->popMax() == 5);
+  assert(stack->top() == 1);
+  assert(stack->peekMax() == 5);
+  assert(stack->pop() == 1);
+  assert(stack->top() == 5);
+}
+
+/**
+ * Your MaxStack object will be instantiated and called as such:
+ * MaxStack* obj = new MaxStack();
+ * obj->push(x);
+ * int param_2 = obj->pop();
+ * int param_3 = obj->top();
+ * int param_4 = obj->peekMax();
+ * int param_5 = obj->popMax();
+ */
+int main()
+{
+  test();
+}

--- a/leetcode/716-MaxStack/maxStack.cc
+++ b/leetcode/716-MaxStack/maxStack.cc
@@ -12,50 +12,45 @@ public:
 
   void push(int x)
   {
-    element_with_cached_max_.emplace(ElementWithCachedMax{x, element_with_cached_max_.empty() ? x : peekMax()});
+    int max = maxStack.empty()? x : maxStack.top();
+    maxStack.emplace(max > x ? max: x);
+    stk.emplace(x);
   }
 
   int pop()
   {
-    int pop_element = element_with_cached_max_.top().element;
-    element_with_cached_max_.pop();
+    int pop_element = stk.top();
+    maxStack.pop();
+    stk.pop();
     return pop_element;
   }
 
   int top()
   {
-    return element_with_cached_max_.top().element;
+    return stk.top();
   }
 
   int peekMax()
   {
-    return element_with_cached_max_.top().max;
+    return maxStack.top();
   }
 
   int popMax()
   {
-    stack<ElementWithCachedMax> buffer;
-    while (element_with_cached_max_.top().element != element_with_cached_max_.top().max)
-    {
-      buffer.emplace(element_with_cached_max_.top());
-      element_with_cached_max_.pop();
-    }
-    int pop_max = element_with_cached_max_.top().element;
-    element_with_cached_max_.pop();
-    while (!buffer.empty())
-    {
-      element_with_cached_max_.emplace(buffer.top());
+    int max = peekMax();
+    stack<int> buffer;
+    while(top() != max) buffer.emplace(pop());
+    pop();
+    while(!buffer.empty()) {
+      push(buffer.top());
       buffer.pop();
     }
-    return pop_max;
+    return max;
   }
 
 private:
-  struct ElementWithCachedMax
-  {
-    int element, max;
-  };
-  stack<ElementWithCachedMax> element_with_cached_max_;
+  stack<int> stk;
+  stack<int> maxStack;
 };
 
 void test() {

--- a/leetcode/CMakeLists.txt
+++ b/leetcode/CMakeLists.txt
@@ -50,7 +50,7 @@ add_executable(21-cpp
   ${INCLUDE_DIR}/cppinclude/linkedList.cc
   ${INCLUDE_DIR}/cppinclude/cpputility.cc)
 target_include_directories(21-cpp PRIVATE ${INCLUDE_DIR}/cppinclude)
-add_test(NAME mergeTwoSortedList.cc COMMAND make 21-cpp)
+add_test(NAME mergeTwoSortedList.cc COMMAND 21-cpp)
 
 add_executable(22
   22-GenerateParentheses/generateParentheses.cc)
@@ -561,6 +561,10 @@ target_include_directories(675 PRIVATE ${INCLUDE_DIR}/cppinclude)
         
 add_executable(704
   704-BinarySearch/binarySearch.cc)
+
+add_executable(716
+  716-MaxStack/maxStack.cc)
+add_test(NAME maxStack.cc COMMAND 716)
 
 add_executable(739
   739-DailyTemperatures/dailyTemperatures.cc)


### PR DESCRIPTION
<!-- Title format: [LC401][Go][Backtracking][v1] -->
<!-- Summary: Which problem solved -->
<!-- Main Techniques: Main techniques used to solved the problem  -->
<!-- Runtime Complexity Analysis -->
<!-- Space Complexity Analysis -->
<!-- Testing: How did you test your changes? Any bugs or defects discovered? -->
<!-- Performance: Performance measures about the solution -->
<!-- Performance Metrics from OJ Platform: Performance reported from OJ Platform (e.g., Leetcode) -->
<!-- Performance Improved Since Last Change: Performance improved compared to the existing solution in the codebase -->
<!-- Implementation Notice: places where we should be careful during implementation; places that are easy to make mistakes -->
<!-- Implementation Tricks: Engineering/Implementation tricks -->
<!-- To Do: what left to be done -->
<!-- To Learn: what can be further learned from this question (technique, algorithm, theory?) -->
<!-- Questions: What questions need further investigation -->
<!-- Languages: highlight of language usage -->
<!-- Failure Attempts: failure attempts and lesson learned from those attempts -->

## Summary

Resolves: [Leetcode 716](https://leetcode.com/problems/max-stack/)

## Main Techniques:


## Runtime Complexity Analysis


## Space Complexity Analysis


## Testing


## Performance

### Performance Metrics from OJ Platform

```
Runtime: 164 ms, faster than 5.21% of C++ online submissions for Max Stack.
Memory Usage: 36.2 MB, less than 22.22% of C++ online submissions for Max Stack.
```

### Performance Improved Since Last Change

## Implementation Notice

The tricky part of the implementation is `popMax()`, which can be seen by the following test case:

```
["MaxStack","push","push","popMax","peekMax"]
[[],[5],[1],[],[]]
```

The correct result is

```
[null,null,null,5,1]
```

The commonly incorrect result we can get is

```
[null,null,null,5,5]
```

The root cause is once we remove the max element, we also need to update the new max element of the stack, which is tricky to do. To get implementation correctly, notice where we use `pop()` and `push()` from our own implementation rather than using the `stack` library implementation.

## Implementation Tricks

## To Do

We need to implement the test infrastructure similar to leetcode's test case, like the one shown above.

## To Learn

There exists a more efficient solution. Probably [this](https://leetcode.com/problems/max-stack/discuss/482406/Sorry-python-but-C++-and-STL-is-better-suited-here.-94-time-92-mem).

## Questions


## Language


## Failure Attempts

```cpp
class MaxStack
{
public:
  /** initialize your data structure here. */
  MaxStack()
  {
  }

  void push(int x)
  {
    element_with_cached_max_.emplace(ElementWithCachedMax{x, element_with_cached_max_.empty() ? x : peekMax()});
  }

  int pop()
  {
    int pop_element = element_with_cached_max_.top().element;
    element_with_cached_max_.pop();
    return pop_element;
  }

  int top()
  {
    return element_with_cached_max_.top().element;
  }

  int peekMax()
  {
    return element_with_cached_max_.top().max;
  }

  int popMax()
  {
    stack<ElementWithCachedMax> buffer;
    while (element_with_cached_max_.top().element != element_with_cached_max_.top().max)
    {
      buffer.emplace(element_with_cached_max_.top());
      element_with_cached_max_.pop();
    }
    int pop_max = element_with_cached_max_.top().element;
    element_with_cached_max_.pop();
    while (!buffer.empty())
    {
      element_with_cached_max_.emplace(buffer.top());
      buffer.pop();
    }
    return pop_max;
  }

private:
  struct ElementWithCachedMax
  {
    int element, max;
  };
  stack<ElementWithCachedMax> element_with_cached_max_;
};
```

The above implementation comes from EPI 8.1, which is correct if we only need `peakMax()` and no `popMax()` involved.